### PR TITLE
Require mcrypt

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,6 +8,7 @@
 	<author>Lukas Reschke</author>
 	<version>1.3.0</version>
 	<dependencies>
+		<lib>mcrypt</lib>
 		<nextcloud min-version="12" max-version="12" />
 	</dependencies>
 	<namespace>User_SAML</namespace>


### PR DESCRIPTION
The SAML library that we use requires mcrypt at the moment.

Fixes https://github.com/nextcloud/user_saml/issues/55

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>