### PR TITLE
Support SSL reverse proxy by default

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -35,7 +35,8 @@ $request = \OC::$server->getRequest();
 $userSession = \OC::$server->getUserSession();
 $samlSettings = new \OCA\User_SAML\SAMLSettings(
 	$urlGenerator,
-	$config
+	$config,
+  $request
 );
 
 $userBackend = new \OCA\User_SAML\UserBackend(

--- a/lib/samlsettings.php
+++ b/lib/samlsettings.php
@@ -23,6 +23,7 @@ namespace OCA\User_SAML;
 
 use OCP\AppFramework\Http;
 use OCP\IConfig;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class SAMLSettings {
@@ -30,20 +31,26 @@ class SAMLSettings {
 	private $urlGenerator;
 	/** @var IConfig */
 	private $config;
+	/** @var IRequest */
+	private $request;
 
 	/**
 	 * @param IURLGenerator $urlGenerator
 	 * @param IConfig $config
+   * @param IRequest $request
 	 */
 	public function __construct(IURLGenerator $urlGenerator,
-								IConfig $config) {
+								IConfig $config,
+                IRequest $request) {
 		$this->urlGenerator = $urlGenerator;
 		$this->config = $config;
+		$this->request = $request;
 	}
 
 	public function getOneLoginSettingsArray() {
 		$settings = [
 			'strict' => true,
+      'baseurl' => $this->request->getServerProtocol() . '://' . $this->request->getServerHost(),
 			'debug' => $this->config->getSystemValue('debug', false),
 			'security' => [
 				'nameIdEncrypted' => ($this->config->getAppValue('user_saml', 'security-nameIdEncrypted', '0') === '1') ? true : false,


### PR DESCRIPTION
Currently this library does not work correctly behind a SSL reverse proxy or https load balancer because proxy headers are ignored as default in OneLogin (see OneLogin_Saml2_Utils::getProxyVars).

To make user_saml work better out-of-the-box in above scenario, base_url is set for OneLogin by using nextcloud's existing methods to resolve correct base URL (which in turn respect the HTTP_X_FORWARDED_HOST and HTTP_X_FORWARDED_PROTO headers).

This partly solves issue #47 