### PR TITLE
Fix SingleLogout with Nextcloud 12

### DIFF
--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Auth.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Auth.php
@@ -34,6 +34,14 @@ class OneLogin_Saml2_Auth
      */
     private $_nameidFormat;
 
+
+    /**
+     * NameID NameQualifier
+     *
+     * @var string
+     */
+    private $_nameidNameQualifier;
+
     /**
      * If user is authenticated.
      *
@@ -177,6 +185,7 @@ class OneLogin_Saml2_Auth
                 $this->_attributes = $response->getAttributes();
                 $this->_nameid = $response->getNameId();
                 $this->_nameidFormat = $response->getNameIdFormat();
+                $this->_nameidNameQualifier = $response->getNameIdNameQualifier();
                 $this->_authenticated = true;
                 $this->_sessionIndex = $response->getSessionIndex();
                 $this->_sessionExpiration = $response->getSessionNotOnOrAfter();
@@ -337,6 +346,16 @@ class OneLogin_Saml2_Auth
     }
 
     /**
+     * Returns the nameID NameQualifier
+     *
+     * @return string  The nameID NameQualifier of the assertion
+     */
+    public function getNameIdNameQualifier()
+    {
+        return $this->_nameidNameQualifier;
+    }
+
+    /**
      * Returns the SessionIndex
      *
      * @return string|null  The SessionIndex of the assertion
@@ -442,12 +461,13 @@ class OneLogin_Saml2_Auth
      * @param string|null $sessionIndex  The SessionIndex (taken from the SAML Response in the SSO process).
      * @param bool        $stay          True if we want to stay (returns the url string) False to redirect
      * @param string|null $nameIdFormat  The NameID Format will be set in the LogoutRequest.
+     * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
      *
      * @return If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
      * @throws OneLogin_Saml2_Error
      */
-    public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null)
+    public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null)
     {
         assert('is_array($parameters)');
 
@@ -466,7 +486,7 @@ class OneLogin_Saml2_Auth
             $nameIdFormat = $this->_nameidFormat;
         }
 
-        $logoutRequest = new OneLogin_Saml2_LogoutRequest($this->_settings, null, $nameId, $sessionIndex, $nameIdFormat);
+        $logoutRequest = new OneLogin_Saml2_LogoutRequest($this->_settings, null, $nameId, $sessionIndex, $nameIdFormat, $nameIdNameQualifier);
 
         $this->_lastRequest = $logoutRequest->getXML();
         $this->_lastRequestID = $logoutRequest->id;

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/LogoutRequest.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/LogoutRequest.php
@@ -38,8 +38,9 @@ class OneLogin_Saml2_LogoutRequest
      * @param string|null             $nameId       The NameID that will be set in the LogoutRequest.
      * @param string|null             $sessionIndex The SessionIndex (taken from the SAML Response in the SSO process).
      * @param string|null             $nameIdFormat The NameID Format will be set in the LogoutRequest.
+     * @param string|null             $nameIdNameQualifier The NameID Qualifier will be set in the LogoutRequest.
      */
-    public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
+    public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $nameIdNameQualifier = null)
     {
         $this->_settings = $settings;
 
@@ -79,7 +80,8 @@ class OneLogin_Saml2_LogoutRequest
                 $nameId,
                 $spNameQualifier,
                 $nameIdFormat,
-                $cert
+                $cert,
+                $nameIdNameQualifier
             );
 
             $sessionIndexStr = isset($sessionIndex) ? "<samlp:SessionIndex>{$sessionIndex}</samlp:SessionIndex>" : "";

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Response.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Response.php
@@ -642,6 +642,21 @@ class OneLogin_Saml2_Response
     }
 
     /**
+     * Gets the NameID NameQualifier provided by the SAML response from the IdP.
+     *
+     * @return string Name ID NameQualifier
+     */
+    public function getNameIdNameQualifier()
+    {
+        $nameIdNameQualifier = null;
+        $nameIdData = $this->getNameIdData();
+        if (!empty($nameIdData) && isset($nameIdData['NameQualifier'])) {
+            $nameIdNameQualifier = $nameIdData['NameQualifier'];
+        }
+        return $nameIdNameQualifier;
+    }
+
+    /**
      * Gets the SessionNotOnOrAfter from the AuthnStatement.
      * Could be used to set the local session expiration
      *

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Utils.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Utils.php
@@ -947,7 +947,7 @@ class OneLogin_Saml2_Utils
      *
      * @return string $nameIDElement DOMElement | XMLSec nameID
      */
-    public static function generateNameId($value, $spnq, $format, $cert = null)
+    public static function generateNameId($value, $spnq, $format, $cert = null, $nq = null)
     {
 
         $doc = new DOMDocument();
@@ -955,6 +955,9 @@ class OneLogin_Saml2_Utils
         $nameId = $doc->createElement('saml:NameID');
         if (isset($spnq)) {
             $nameId->setAttribute('SPNameQualifier', $spnq);
+        }
+        if (isset($nq)) {
+            $nameId->setAttribute('NameQualifier', $nq);
         }
         $nameId->setAttribute('Format', $format);
         $nameId->appendChild($doc->createTextNode($value));

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -60,6 +60,11 @@ switch($config->getAppValue('user_saml', 'type')) {
 			$returnScript = true;
 		}
 		$type = 'saml';
+
+		// Register UserHooks to handle SLO
+		$app=new \OCA\User_SAML\AppInfo\Application();
+		$app->getContainer()->query('UserHooks')->register();
+
 		break;
 	case 'environment-variable':
 		$type = 'environment-variable';

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -39,6 +39,11 @@ return [
 			'verb' => 'POST',
 		],
 		[
+			'name' => 'SAML#logout',
+			'url' => '/saml/logout',
+			'verb' => 'GET',
+		],
+		[
 			'name' => 'SAML#singleLogoutService',
 			'url' => '/saml/sls',
 			'verb' => 'GET',

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,7 @@ use OCA\User_SAML\Controller\SAMLController;
 use OCA\User_SAML\Middleware\OnlyLoggedInMiddleware;
 use OCA\User_SAML\SAMLSettings;
 use OCA\User_SAML\UserBackend;
+use OCA\User_SAML\Hooks\UserHooks;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 
@@ -43,5 +44,14 @@ class Application extends App {
 			);
 		});
 		$container->registerMiddleWare('OnlyLoggedInMiddleware');
+
+		/**
+		 * UserSession Hooks
+		 */
+		$container->registerService('UserHooks', function($c) {
+			return new UserHooks(
+				$c->query('ServerContainer')->getUserSession()
+			);
+		});
 	}
 }

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -41,7 +41,7 @@ class UserHooks {
             $urlGenerator,
             $config
         );
-        if ($config->getAppValue('user_saml', 'type')=='saml' && $this->userSession->getSession()->exists('user_saml.samlNameId')) {
+        if ($config->getAppValue('user_saml', 'type')==='saml' && $this->userSession->getSession()->exists('user_saml.samlNameId')) {
             $csrfToken = \OC::$server->getCsrfTokenManager()->getToken();
             header('Location: '.$urlGenerator->linkToRouteAbsolute('user_saml.SAML.logout') .'?requesttoken='. urlencode($csrfToken->getEncryptedValue()));
             exit();

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Benjamin Renard <brenard@easter-eggs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Hooks;
+use OCP\IUserSession;
+
+class UserHooks {
+
+    private $userSession;
+
+    public function __construct(IUserSession $userSession){
+        $this->userSession = $userSession;
+    }
+
+    public function register() {
+        $this->userSession->listen('\OC\User', 'logout', array($this, 'onLogout'));
+    }
+
+    public function onLogout() {
+        $config = \OC::$server->getConfig();
+        $urlGenerator = \OC::$server->getURLGenerator();
+        $samlSettings = new \OCA\User_SAML\SAMLSettings(
+            $urlGenerator,
+            $config
+        );
+        if ($config->getAppValue('user_saml', 'type')=='saml' && $this->userSession->getSession()->exists('user_saml.samlNameId')) {
+            $csrfToken = \OC::$server->getCsrfTokenManager()->getToken();
+            header('Location: '.$urlGenerator->linkToRouteAbsolute('user_saml.SAML.logout') .'?requesttoken='. urlencode($csrfToken->getEncryptedValue()));
+            exit();
+        }
+        return True;
+    }
+
+}
+

--- a/tests/unit/AppInfo/RoutesTest.php
+++ b/tests/unit/AppInfo/RoutesTest.php
@@ -45,6 +45,11 @@ class Test extends TestCase  {
 					'verb' => 'POST',
 				],
 				[
+					'name' => 'SAML#logout',
+					'url' => '/saml/logout',
+					'verb' => 'GET',
+				],
+				[
 					'name' => 'SAML#singleLogoutService',
 					'url' => '/saml/sls',
 					'verb' => 'GET',


### PR DESCRIPTION
Hello,

Since Nextcloud 12, Single Logout not working : the logout interface link not using any more the user backend _getLogoutAttribute()_ method. To handle logout, we have to use _logout_ hook to trigger the _SLO_ request. Moreever, the _SLO Response_ was not correctly handle by using _php-saml processSLO()_ method.

My fix implement a trigger on _logout_ hook to redirect user (if it's logged by using _php-saml_) to new logout URL manage by _SAMLController_. This URL make the _SLO Request_ and the old _singleLogoutService_ now handle the _SLO Response_ by calling _php-saml processSLO()_ method and redirect user to standard Nextcloud _logout_ URL.

I also fix another bug regarding SAML standard : In the _SLO Request_, the _NameID_ element must be exactly the same as provided by the SSO server on the _SSO Response_. I personally use [Authentic2 SSO Server](https://dev.entrouvert.org//projects/authentic) which is really strict about that. To fix it, I made some changes on _php-saml_ library to permit to set _nameId NameQualifier_ attribute in _SLO Request_. This changes have been proposed and merged upstream (https://github.com/onelogin/php-saml/pull/226). In _user_saml_, I made some changes to retrieve and store in session the _nameId NameQualifier_ attribute's value of the _SSO Response_ and pass it on _SLO Request_.