### PR TITLE
Support the ability to parse IdP XML metadata

### DIFF
--- a/3rdparty/composer.lock
+++ b/3rdparty/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "onelogin/php-saml",
-            "version": "2.10.5",
+            "version": "2.10.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/onelogin/php-saml.git",
-                "reference": "3319d7707f342e38291eee6b01a4a5f8df1b333b"
+                "reference": "b41f731803f303879f50fa76276908088197731c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/onelogin/php-saml/zipball/3319d7707f342e38291eee6b01a4a5f8df1b333b",
-                "reference": "3319d7707f342e38291eee6b01a4a5f8df1b333b",
+                "url": "https://api.github.com/repos/onelogin/php-saml/zipball/b41f731803f303879f50fa76276908088197731c",
+                "reference": "b41f731803f303879f50fa76276908088197731c",
                 "shasum": ""
             },
             "require": {
@@ -58,7 +58,7 @@
                 "onelogin",
                 "saml"
             ],
-            "time": "2017-03-13T09:56:49+00:00"
+            "time": "2017-05-19T10:32:03+00:00"
         }
     ],
     "packages-dev": [],

--- a/3rdparty/vendor/composer/ClassLoader.php
+++ b/3rdparty/vendor/composer/ClassLoader.php
@@ -374,9 +374,13 @@ class ClassLoader
 
         $first = $class[0];
         if (isset($this->prefixLengthsPsr4[$first])) {
-            foreach ($this->prefixLengthsPsr4[$first] as $prefix => $length) {
-                if (0 === strpos($class, $prefix)) {
-                    foreach ($this->prefixDirsPsr4[$prefix] as $dir) {
+            $subPath = $class;
+            while (false !== $lastPos = strrpos($subPath, '\\')) {
+                $subPath = substr($subPath, 0, $lastPos);
+                $search = $subPath.'\\';
+                if (isset($this->prefixDirsPsr4[$search])) {
+                    foreach ($this->prefixDirsPsr4[$search] as $dir) {
+                        $length = $this->prefixLengthsPsr4[$first][$search];
                         if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
                             return $file;
                         }

--- a/3rdparty/vendor/composer/LICENSE
+++ b/3rdparty/vendor/composer/LICENSE
@@ -1,5 +1,5 @@
 
-Copyright (c) 2016 Nils Adermann, Jordi Boggiano
+Copyright (c) Nils Adermann, Jordi Boggiano
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/3rdparty/vendor/composer/autoload_classmap.php
+++ b/3rdparty/vendor/composer/autoload_classmap.php
@@ -10,6 +10,7 @@ return array(
     'OneLogin_Saml2_AuthnRequest' => $vendorDir . '/onelogin/php-saml/lib/Saml2/AuthnRequest.php',
     'OneLogin_Saml2_Constants' => $vendorDir . '/onelogin/php-saml/lib/Saml2/Constants.php',
     'OneLogin_Saml2_Error' => $vendorDir . '/onelogin/php-saml/lib/Saml2/Error.php',
+    'OneLogin_Saml2_IdPMetadataParser' => $vendorDir . '/onelogin/php-saml/lib/Saml2/IdPMetadataParser.php',
     'OneLogin_Saml2_LogoutRequest' => $vendorDir . '/onelogin/php-saml/lib/Saml2/LogoutRequest.php',
     'OneLogin_Saml2_LogoutResponse' => $vendorDir . '/onelogin/php-saml/lib/Saml2/LogoutResponse.php',
     'OneLogin_Saml2_Metadata' => $vendorDir . '/onelogin/php-saml/lib/Saml2/Metadata.php',

--- a/3rdparty/vendor/composer/autoload_static.php
+++ b/3rdparty/vendor/composer/autoload_static.php
@@ -11,6 +11,7 @@ class ComposerStaticInitcc75f134f7630c1ee3a8e4d7c86f3bcc
         'OneLogin_Saml2_AuthnRequest' => __DIR__ . '/..' . '/onelogin/php-saml/lib/Saml2/AuthnRequest.php',
         'OneLogin_Saml2_Constants' => __DIR__ . '/..' . '/onelogin/php-saml/lib/Saml2/Constants.php',
         'OneLogin_Saml2_Error' => __DIR__ . '/..' . '/onelogin/php-saml/lib/Saml2/Error.php',
+        'OneLogin_Saml2_IdPMetadataParser' => __DIR__ . '/..' . '/onelogin/php-saml/lib/Saml2/IdPMetadataParser.php',
         'OneLogin_Saml2_LogoutRequest' => __DIR__ . '/..' . '/onelogin/php-saml/lib/Saml2/LogoutRequest.php',
         'OneLogin_Saml2_LogoutResponse' => __DIR__ . '/..' . '/onelogin/php-saml/lib/Saml2/LogoutResponse.php',
         'OneLogin_Saml2_Metadata' => __DIR__ . '/..' . '/onelogin/php-saml/lib/Saml2/Metadata.php',

--- a/3rdparty/vendor/composer/installed.json
+++ b/3rdparty/vendor/composer/installed.json
@@ -1,17 +1,17 @@
 [
     {
         "name": "onelogin/php-saml",
-        "version": "2.10.5",
-        "version_normalized": "2.10.5.0",
+        "version": "2.10.7",
+        "version_normalized": "2.10.7.0",
         "source": {
             "type": "git",
             "url": "https://github.com/onelogin/php-saml.git",
-            "reference": "3319d7707f342e38291eee6b01a4a5f8df1b333b"
+            "reference": "b41f731803f303879f50fa76276908088197731c"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/onelogin/php-saml/zipball/3319d7707f342e38291eee6b01a4a5f8df1b333b",
-            "reference": "3319d7707f342e38291eee6b01a4a5f8df1b333b",
+            "url": "https://api.github.com/repos/onelogin/php-saml/zipball/b41f731803f303879f50fa76276908088197731c",
+            "reference": "b41f731803f303879f50fa76276908088197731c",
             "shasum": ""
         },
         "require": {
@@ -33,7 +33,7 @@
             "ext-mcrypt": "Install mcrypt and php5-mcrypt libs in order to support encryption",
             "lib-openssl": "Install openssl lib in order to handle with x509 certs (require to support sign and encryption)"
         },
-        "time": "2017-03-13T09:56:49+00:00",
+        "time": "2017-05-19T10:32:03+00:00",
         "type": "library",
         "installation-source": "dist",
         "autoload": {

--- a/3rdparty/vendor/onelogin/php-saml/.gitignore
+++ b/3rdparty/vendor/onelogin/php-saml/.gitignore
@@ -6,6 +6,7 @@
 /demo-old/settings.php
 /certs/sp.key
 /certs/sp.crt
+/certs/sp_new.crt
 /certs/metadata.key
 /certs/metadata.crt
 /tests/build

--- a/3rdparty/vendor/onelogin/php-saml/CHANGELOG
+++ b/3rdparty/vendor/onelogin/php-saml/CHANGELOG
@@ -1,5 +1,14 @@
 CHANGELOG
 =========
+v.2.10.7
+* Fix IdPMetadataParser. The SingleLogoutService retrieved method was wrong
+* [#201](https://github.com/onelogin/php-saml/issues/201) Fix issues with SP entity_id, acs url and sls url that contains &
+
+v.2.10.6
+* [#206](https://github.com/onelogin/php-saml/pull/206)Be able to register future SP x509cert on the settings and publish it on SP metadata
+* [#206](https://github.com/onelogin/php-saml/pull/206) Be able to register more than 1 Identity Provider x509cert, linked with an specific use (signing or encryption)
+* [#206](https://github.com/onelogin/php-saml/pull/206) Support the ability to parse IdP XML metadata (remote url or file) and be able to inject the data obtained on the settings.
+
 v.2.10.5
 * Be able to get at the auth object the last processed ID
 * Improve NameID Format support

--- a/3rdparty/vendor/onelogin/php-saml/README.md
+++ b/3rdparty/vendor/onelogin/php-saml/README.md
@@ -86,6 +86,7 @@ Installation
  * `mcrypt`. Install that library and its php driver if you gonna handle
    encrypted data (`nameID`, `assertions`).
  * `gettext`. Install that library and its php driver. It handles translations.
+ * `curl`. Install that library and its php driver if you plan to use the IdP Metadata parser.
 
 Since [PHP 5.3 is officially unsupported](http://php.net/eol.php) we recommend you to use a newer PHP version.
 
@@ -183,6 +184,8 @@ Sometimes we could need a signature on the metadata published by the SP, in
 this case we could use the x.509 cert previously mentioned or use a new x.509
 cert: `metadata.crt` and `metadata.key`.
 
+Use `sp_new.crt` if you are in a key rollover process and you want to
+publish that x509certificate on Service Provider metadata.
 
 #### `extlib/` ####
 
@@ -285,7 +288,7 @@ $settings = array (
     // Set a BaseURL to be used instead of try to guess
     // the BaseURL of the view that process the SAML Message.
     // Ex http://sp.example.com/
-    //    http://example.com/sp/ 
+    //    http://example.com/sp/
     'baseurl' => null,
 
     // Service Provider Data that we are deploying.
@@ -319,7 +322,7 @@ $settings = array (
                 )
         ),
         // Specifies info about where and how the <Logout Response> message MUST be
-        // returned to the requester, in this case our SP.        
+        // returned to the requester, in this case our SP.
         'singleLogoutService' => array (
             // URL Location where the <Response> from the IdP will be returned
             'url' => '',
@@ -337,6 +340,14 @@ $settings = array (
         'x509cert' => '',
         'privateKey' => '',
 
+        /*
+         * Key rollover
+         * If you plan to update the SP x509cert and privateKey
+         * you can define here the new x509cert and it will be
+         * published on the SP metadata so Identity Providers can
+         * read them and get ready for rollover.
+         */
+        // 'x509certNew' => '',
     ),
 
     // Identity Provider Data that we want connected with our SP.
@@ -379,6 +390,22 @@ $settings = array (
          */
         // 'certFingerprint' => '',
         // 'certFingerprintAlgorithm' => 'sha1',
+
+        /* In some scenarios the IdP uses different certificates for
+         * signing/encryption, or is under key rollover phase and
+         * more than one certificate is published on IdP metadata.
+         * In order to handle that the toolkit offers that parameter.
+         * (when used, 'x509cert' and 'certFingerprint' values are
+         * ignored).
+         */
+        // 'x509certMulti' => array(
+        //      'signing' => array(
+        //          0 => '<cert1-string>',
+        //      ),
+        //      'encryption' => array(
+        //          0 => '<cert2-string>',
+        //      )
+        // ),
     ),
 );
 ```
@@ -427,7 +454,6 @@ $advancedSettings = array (
         */
         'signMetadata' => false,
 
-
         /** signatures and encryptions required **/
 
         // Indicates a requirement for the <samlp:Response>, <samlp:LogoutRequest>
@@ -450,11 +476,10 @@ $advancedSettings = array (
         // this SP to be encrypted.
         'wantNameIdEncrypted' => false,
 
-
         // Authentication context.
-        // Set to false or don't present this parameter and no AuthContext will be sent in the AuthNRequest,
-        // Set true and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
-        // Set an array with the possible auth context values: array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'),
+        // Set to false and no AuthContext will be sent in the AuthNRequest.
+        // Set true or don't present this parameter and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'.
+        // Set an array with the possible auth context values: array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509').
         'requestedAuthnContext' => true,
 
         // Indicates if the SP will validate all received xmls.
@@ -1056,7 +1081,7 @@ if (isset($_SESSION['samlUserdata'])) {   // If there is user data we print it.
 ```
 
 #### URL-guessing methods ####
- 
+
 php-saml toolkit uses a bunch of methods in OneLogin_Saml2_Utils that try to guess the URL where the SAML messages are processed.
 
 * `getSelfHost` Returns the current host.
@@ -1085,9 +1110,29 @@ You should be able to workaround this by configuring your server so that it is a
 Or by using the method described on the previous section.
 
 
-### Reply attacks ###
+### SP Key rollover ###
 
-In order to avoid reply attacks, you can store the ID of the SAML messages already processed, to avoid processing them twice. Since the Messages expires and will be invalidated due that fact, you don't need to store those IDs longer than the time frame that you currently accepting.
+If you plan to update the SP x509cert and privateKey you can define the new x509cert as $settings['sp']['x509certNew'] and it will be
+published on the SP metadata so Identity Providers can read them and get ready for rollover.
+
+
+### IdP with multiple certificates ###
+
+In some scenarios the IdP uses different certificates for
+signing/encryption, or is under key rollover phase and more than one certificate is published on IdP metadata.
+
+In order to handle that the toolkit offers the $settings['idp']['x509certMulti'] parameter.
+
+When that parameter is used, 'x509cert' and 'certFingerprint' values will be ignored by the toolkit.
+
+The 'x509certMulti' is an array with 2 keys:
+- 'signing'. An array of certs that will be used to validate IdP signature
+- 'encryption' An array with one unique cert that will be used to encrypt data to be sent to the IdP
+
+
+### Replay attacks ###
+
+In order to avoid replay attacks, you can store the ID of the SAML messages already processed, to avoid processing them twice. Since the Messages expires and will be invalidated due that fact, you don't need to store those IDs longer than the time frame that you currently accepting.
 
 Get the ID of the last processed message/assertion with the getLastMessageId/getLastAssertionId method of the Auth object.
 
@@ -1250,6 +1295,7 @@ Configuration of the OneLogin PHP Toolkit
  * `checkSPCerts` - Checks if the x509 certs of the SP exists and are valid.
  * `getSPkey` - Returns the x509 private key of the SP.
  * `getSPcert` - Returns the x509 public cert of the SP.
+ * `getSPcertNew` - Returns the future x509 public cert of the SP.
  * `getIdPData` - Gets the IdP data.
  * `getSPData`Gets the SP data.
  * `getSecurityData` - Gets security data.
@@ -1259,6 +1305,7 @@ Configuration of the OneLogin PHP Toolkit
  * `validateMetadata` - Validates an XML SP Metadata.
  * `formatIdPCert` - Formats the IdP cert.
  * `formatSPCert` - Formats the SP cert.
+ * `formatSPCertNew` - Formats the SP cert new.
  * `formatSPKey` - Formats the SP private key.
  * `getErrors` - Returns an array with the errors, the array is empty when
    the settings is ok.
@@ -1316,6 +1363,16 @@ Auxiliary class that contains several methods
  * `addSign` - Adds signature key and senders certificate to an element
    (Message or Assertion).
  * `validateSign` - Validates a signature (Message or Assertion).
+
+##### OneLogin_Saml2_IdPMetadataParser - `IdPMetadataParser.php` #####
+
+Auxiliary class that contains several methods to retrieve and process IdP metadata
+
+ * `parseRemoteXML` - Get IdP Metadata Info from URL.
+ * `parseFileXML` - Get IdP Metadata Info from File.
+ * `parseXML` - Get IdP Metadata Info from XML.
+ * `injectIntoSettings` - Inject metadata info into php-saml settings array.
+
 
 For more info, look at the source code; each method is documented and details
 about what it does and how to use it are provided. Make sure to also check the doc folder where

--- a/3rdparty/vendor/onelogin/php-saml/composer.json
+++ b/3rdparty/vendor/onelogin/php-saml/composer.json
@@ -2,7 +2,7 @@
     "name": "onelogin/php-saml",
     "description": "OneLogin PHP SAML Toolkit",
     "license": "MIT",
-    "version": "2.10.5",
+    "version": "2.10.7",
     "homepage": "https://onelogin.zendesk.com/hc/en-us/sections/200245634-SAML-Toolkits",
     "keywords": ["saml", "saml2", "onelogin"],
     "autoload": {

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/AuthnRequest.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/AuthnRequest.php
@@ -114,6 +114,8 @@ REQUESTEDAUTHN;
             }
         }
 
+        $sp_entity_id = htmlspecialchars($spData['entityId'], ENT_QUOTES);
+        $acs_url = htmlspecialchars($spData['assertionConsumerService']['url'], ENT_QUOTES);
         $request = <<<AUTHNREQUEST
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
@@ -124,8 +126,8 @@ REQUESTEDAUTHN;
     IssueInstant="$issueInstant"
     Destination="{$idpData['singleSignOnService']['url']}"
     ProtocolBinding="{$spData['assertionConsumerService']['binding']}"
-    AssertionConsumerServiceURL="{$spData['assertionConsumerService']['url']}">
-    <saml:Issuer>{$spData['entityId']}</saml:Issuer>
+    AssertionConsumerServiceURL="{$acs_url}">
+    <saml:Issuer>{$sp_entity_id}</saml:Issuer>
 {$nameIdPolicyStr}
 {$requestedAuthnStr}
 </samlp:AuthnRequest>

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/IdPMetadataParser.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/IdPMetadataParser.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * IdP Metadata Parser of OneLogin PHP Toolkit
+ *
+ */
+
+class OneLogin_Saml2_IdPMetadataParser
+{
+    /**
+     * Get IdP Metadata Info from URL
+     *
+     * @param string $url                   URL where the IdP metadata is published
+     * @param string $entityId              Entity Id of the desired IdP, if no
+     *                                      entity Id is provided and the XML
+     *                                      metadata contains more than one
+     *                                      IDPSSODescriptor, the first is returned
+     * @param string $desiredNameIdFormat   If available on IdP metadata, use that nameIdFormat
+     *
+     * @return array metadata info in php-saml settings format
+     */
+    public static function parseRemoteXML($url, $entityId = null, $desiredNameIdFormat = null)
+    {
+        $metadataInfo = array();
+
+        try {
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "GET");
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+            curl_setopt($ch, CURLOPT_FAILONERROR, 1);
+
+            $xml = curl_exec($ch);
+            if ($xml !== false) {
+                $metadataInfo = self::parseXML($xml, $entityId);
+            } else {
+                throw new Exception(curl_error($ch), curl_errno($ch));
+            }
+        } catch (Exception $e) {
+        }
+        return $metadataInfo;
+    }
+
+    /**
+     * Get IdP Metadata Info from File
+     *
+     * @param string $filepath              File path
+     * @param string $entityId              Entity Id of the desired IdP, if no
+     *                                      entity Id is provided and the XML
+     *                                      metadata contains more than one
+     *                                      IDPSSODescriptor, the first is returned
+     * @param string $desiredNameIdFormat   If available on IdP metadata, use that nameIdFormat
+     *
+     * @return array metadata info in php-saml settings format
+     */
+    public static function parseFileXML($filepath, $entityId = null, $desiredNameIdFormat = null)
+    {
+        $metadataInfo = array();
+
+        try {
+            if (file_exists($filepath)) {
+                $data = file_get_contents($filepath);
+                $metadataInfo = self::parseXML($data, $entityId);
+            }
+        } catch (Exception $e) {
+        }
+        return $metadataInfo;
+    }
+
+    /**
+     * Get IdP Metadata Info from URL
+     *
+     * @param string $xml                   XML that contains IdP metadata
+     * @param string $entityId              Entity Id of the desired IdP, if no
+     *                                      entity Id is provided and the XML
+     *                                      metadata contains more than one
+     *                                      IDPSSODescriptor, the first is returned
+     * @param string $desiredNameIdFormat   If available on IdP metadata, use that nameIdFormat
+     *
+     * @return array metadata info in php-saml settings format
+     */
+    public static function parseXML($xml, $entityId = null, $desiredNameIdFormat = null)
+    {
+        $metadataInfo = array();
+
+        $dom = new DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        try {
+            $dom = OneLogin_Saml2_Utils::loadXML($dom, $xml);
+            if (!$dom) {
+                throw new Exception('Error parsing metadata');
+            }
+
+            $customIdPStr = '';
+            if (!empty($entityId)) {
+                $customIdPStr = '[@entityID="' . $entityId . '"]';
+            }
+            $idpDescryptorXPath = '//md:EntityDescriptor' . $customIdPStr . '/md:IDPSSODescriptor';
+
+            $idpDescriptorNodes = OneLogin_Saml2_Utils::query($dom, $idpDescryptorXPath);
+
+            if (isset($idpDescriptorNodes) && $idpDescriptorNodes->length > 0) {
+                $metadataInfo['idp'] = array();
+
+                $idpDescriptor = $idpDescriptorNodes->item(0);
+
+                if (empty($entityId) && $idpDescriptor->parentNode->hasAttribute('entityID')) {
+                    $entityId = $idpDescriptor->parentNode->getAttribute('entityID');
+                }
+
+                if (!empty($entityId)) {
+                    $metadataInfo['idp']['entityId'] = $entityId;
+                }
+
+                $ssoNodes = OneLogin_Saml2_Utils::query($dom, './md:SingleSignOnService[@Binding="'.OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT.'"]', $idpDescriptor);
+                if ($ssoNodes->length < 1) {
+                    $ssoNodes = OneLogin_Saml2_Utils::query($dom, './md:SingleSignOnService', $idpDescriptor);
+                }
+                if ($ssoNodes->length > 0) {
+                    $metadataInfo['idp']['singleSignOnService'] = array(
+                        'url' => $ssoNodes->item(0)->getAttribute('Location'),
+                        'binding' => $ssoNodes->item(0)->getAttribute('Binding')
+                    );
+                }
+
+                $sloNodes = OneLogin_Saml2_Utils::query($dom, './md:SingleLogoutService[@Binding="'.OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT.'"]', $idpDescriptor);
+                if ($sloNodes->length < 1) {
+                    $sloNodes = OneLogin_Saml2_Utils::query($dom, './md:SingleLogoutService', $idpDescriptor);
+                }
+                if ($sloNodes->length > 0) {
+                    $metadataInfo['idp']['singleLogoutService'] = array(
+                        'url' => $sloNodes->item(0)->getAttribute('Location'),
+                        'binding' => $sloNodes->item(0)->getAttribute('Binding')
+                    );
+                }
+
+                $keyDescriptorCertSigningNodes = OneLogin_Saml2_Utils::query($dom, './md:KeyDescriptor[not(contains(@use, "encryption"))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate', $idpDescriptor);
+
+                $keyDescriptorCertEncryptionNodes = OneLogin_Saml2_Utils::query($dom, './md:KeyDescriptor[not(contains(@use, "signing"))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate', $idpDescriptor);
+
+                if (!empty($keyDescriptorCertSigningNodes) || !empty($keyDescriptorCertEncryptionNodes)) {
+                    $metadataInfo['idp']['x509certMulti'] = array();
+                    if (!empty($keyDescriptorCertSigningNodes)) {
+                        $idpInfo['x509certMulti']['signing'] = array();
+                        foreach ($keyDescriptorCertSigningNodes as $keyDescriptorCertSigningNode) {
+                            $metadataInfo['idp']['x509certMulti']['signing'][] = OneLogin_Saml2_Utils::formatCert($keyDescriptorCertSigningNode->nodeValue, false);
+                        }
+                    }
+                    if (!empty($keyDescriptorCertEncryptionNodes)) {
+                        $idpInfo['x509certMulti']['encryption'] = array();
+                        foreach ($keyDescriptorCertEncryptionNodes as $keyDescriptorCertEncryptionNode) {
+                            $metadataInfo['idp']['x509certMulti']['encryption'][] = OneLogin_Saml2_Utils::formatCert($keyDescriptorCertEncryptionNode->nodeValue, false);
+                        }
+                    }
+
+                    $idpCertdata = $metadataInfo['idp']['x509certMulti'];
+                    if (count($idpCertdata) == 1 || ((isset($idpCertdata['signing']) && count($idpCertdata['signing']) == 1) && isset($idpCertdata['encryption']) && count($idpCertdata['encryption']) == 1 && strcmp($idpCertdata['signing'][0], $idpCertdata['encryption'][0]) == 0)) {
+                        if (isset($metadataInfo['idp']['x509certMulti']['signing'][0])) {
+                            $metadataInfo['idp']['x509cert'] = $metadataInfo['idp']['x509certMulti']['signing'][0];
+                        } else {
+                            $metadataInfo['idp']['x509cert'] = $metadataInfo['idp']['x509certMulti']['encryption'][0];
+                        }
+                        unset($metadataInfo['idp']['x509certMulti']);
+                    }
+                }
+
+                $nameIdFormatNodes = OneLogin_Saml2_Utils::query($dom, './md:NameIDFormat', $idpDescriptor);
+                if ($nameIdFormatNodes->length > 0) {
+                    $metadataInfo['sp']['NameIDFormat'] = $nameIdFormatNodes->item(0)->nodeValue;
+                    if (!empty($desiredNameIdFormat)) {
+                        foreach ($nameIdFormatNodes as $nameIdFormatNode) {
+                            if (strcmp($nameIdFormatNode->nodeValue, $desiredNameIdFormat) == 0) {
+                                $metadataInfo['sp']['NameIDFormat'] = $nameIdFormatNode->nodeValue;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception $e) {
+            throw new Exception('Error parsing metadata. '.$e->getMessage());
+        }
+
+        return $metadataInfo;
+    }
+
+    /**
+     * Inject metadata info into php-saml settings array
+     *
+     * @param string $settings      php-saml settings array
+     * @param string $metadataInfo  array metadata info
+     *
+     * @return array settings
+     */
+    public static function injectIntoSettings($settings, $metadataInfo)
+    {
+        if (isset($metadataInfo['idp']) && isset($settings['idp'])) {
+            if (isset($metadataInfo['idp']['x509certMulti']) && !empty($metadataInfo['idp']['x509certMulti']) && isset($settings['idp']['x509cert'])) {
+                unset($settings['idp']['x509cert']);
+            }
+
+            if (isset($metadataInfo['idp']['x509cert']) && !empty($metadataInfo['idp']['x509cert']) && isset($settings['idp']['x509certMulti'])) {
+                unset($settings['idp']['x509certMulti']);
+            }
+        }
+
+        return array_replace_recursive($settings, $metadataInfo);
+    }
+}

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/LogoutRequest.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/LogoutRequest.php
@@ -61,7 +61,13 @@ class OneLogin_Saml2_LogoutRequest
 
             $cert = null;
             if (isset($security['nameIdEncrypted']) && $security['nameIdEncrypted']) {
-                $cert = $idpData['x509cert'];
+                $existsMultiX509Enc = isset($idpData['x509certMulti']) && isset($idpData['x509certMulti']['encryption']) && !empty($idpData['x509certMulti']['encryption']);
+
+                if ($existsMultiX509Enc) {
+                    $cert = $idpData['x509certMulti']['encryption'][0];
+                } else {
+                    $cert = $idpData['x509cert'];
+                }
             }
 
             if (!empty($nameId)) {
@@ -84,6 +90,7 @@ class OneLogin_Saml2_LogoutRequest
 
             $sessionIndexStr = isset($sessionIndex) ? "<samlp:SessionIndex>{$sessionIndex}</samlp:SessionIndex>" : "";
 
+            $sp_entity_id = htmlspecialchars($spData['entityId'], ENT_QUOTES);
             $logoutRequest = <<<LOGOUTREQUEST
 <samlp:LogoutRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
@@ -92,7 +99,7 @@ class OneLogin_Saml2_LogoutRequest
     Version="2.0"
     IssueInstant="{$issueInstant}"
     Destination="{$idpData['singleLogoutService']['url']}">
-    <saml:Issuer>{$spData['entityId']}</saml:Issuer>
+    <saml:Issuer>{$sp_entity_id}</saml:Issuer>
     {$nameIdObj}
     {$sessionIndexStr}
 </samlp:LogoutRequest>
@@ -357,49 +364,8 @@ LOGOUTREQUEST;
             }
 
             if (isset($_GET['Signature'])) {
-                if (!isset($_GET['SigAlg'])) {
-                    $signAlg = XMLSecurityKey::RSA_SHA1;
-                } else {
-                    $signAlg = $_GET['SigAlg'];
-                }
-
-                if ($retrieveParametersFromServer) {
-                    $signedQuery = 'SAMLRequest='.OneLogin_Saml2_Utils::extractOriginalQueryParam('SAMLRequest');
-                    if (isset($_GET['RelayState'])) {
-                        $signedQuery .= '&RelayState='.OneLogin_Saml2_Utils::extractOriginalQueryParam('RelayState');
-                    }
-                    $signedQuery .= '&SigAlg='.OneLogin_Saml2_Utils::extractOriginalQueryParam('SigAlg');
-                } else {
-                    $signedQuery = 'SAMLRequest='.urlencode($_GET['SAMLRequest']);
-                    if (isset($_GET['RelayState'])) {
-                        $signedQuery .= '&RelayState='.urlencode($_GET['RelayState']);
-                    }
-                    $signedQuery .= '&SigAlg='.urlencode($signAlg);
-                }
-
-                if (!isset($idpData['x509cert']) || empty($idpData['x509cert'])) {
-                    throw new OneLogin_Saml2_Error(
-                        "In order to validate the sign on the Logout Request, the x509cert of the IdP is required",
-                        OneLogin_Saml2_Error::CERT_NOT_FOUND
-                    );
-                }
-                $cert = $idpData['x509cert'];
-
-                $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' => 'public'));
-                $objKey->loadKey($cert, false, true);
-
-                if ($signAlg != XMLSecurityKey::RSA_SHA1) {
-                    try {
-                        $objKey = OneLogin_Saml2_Utils::castKey($objKey, $signAlg, 'public');
-                    } catch (Exception $e) {
-                        throw new OneLogin_Saml2_ValidationError(
-                            "Invalid signAlg in the recieved Logout Request",
-                            OneLogin_Saml2_ValidationError::INVALID_SIGNATURE
-                        );
-                    }
-                }
-
-                if ($objKey->verifySignature($signedQuery, base64_decode($_GET['Signature'])) !== 1) {
+                $signatureValid = OneLogin_Saml2_Utils::validateBinarySign("SAMLRequest", $_GET, $idpData, $retrieveParametersFromServer);
+                if (!$signatureValid) {
                     throw new OneLogin_Saml2_ValidationError(
                         "Signature validation failed. Logout Request rejected",
                         OneLogin_Saml2_ValidationError::INVALID_SIGNATURE

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/LogoutResponse.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/LogoutResponse.php
@@ -175,49 +175,8 @@ class OneLogin_Saml2_LogoutResponse
             }
 
             if (isset($_GET['Signature'])) {
-                if (!isset($_GET['SigAlg'])) {
-                    $signAlg = XMLSecurityKey::RSA_SHA1;
-                } else {
-                    $signAlg = $_GET['SigAlg'];
-                }
-
-                if ($retrieveParametersFromServer) {
-                    $signedQuery = 'SAMLResponse='.OneLogin_Saml2_Utils::extractOriginalQueryParam('SAMLResponse');
-                    if (isset($_GET['RelayState'])) {
-                        $signedQuery .= '&RelayState='.OneLogin_Saml2_Utils::extractOriginalQueryParam('RelayState');
-                    }
-                    $signedQuery .= '&SigAlg='.OneLogin_Saml2_Utils::extractOriginalQueryParam('SigAlg');
-                } else {
-                    $signedQuery = 'SAMLResponse='.urlencode($_GET['SAMLResponse']);
-                    if (isset($_GET['RelayState'])) {
-                        $signedQuery .= '&RelayState='.urlencode($_GET['RelayState']);
-                    }
-                    $signedQuery .= '&SigAlg='.urlencode($signAlg);
-                }
-
-                if (!isset($idpData['x509cert']) || empty($idpData['x509cert'])) {
-                    throw new OneLogin_Saml2_Error(
-                        "In order to validate the sign on the Logout Response, the x509cert of the IdP is required",
-                        OneLogin_Saml2_Error::CERT_NOT_FOUND
-                    );
-                }
-                $cert = $idpData['x509cert'];
-
-                $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' => 'public'));
-                $objKey->loadKey($cert, false, true);
-
-                if ($signAlg != XMLSecurityKey::RSA_SHA1) {
-                    try {
-                        $objKey = OneLogin_Saml2_Utils::castKey($objKey, $signAlg, 'public');
-                    } catch (Exception $e) {
-                        throw new OneLogin_Saml2_ValidationError(
-                            "Invalid signAlg in the recieved Logout Response",
-                            OneLogin_Saml2_ValidationError::INVALID_SIGNATURE
-                        );
-                    }
-                }
-
-                if ($objKey->verifySignature($signedQuery, base64_decode($_GET['Signature'])) !== 1) {
+                $signatureValid = OneLogin_Saml2_Utils::validateBinarySign("SAMLResponse", $_GET, $idpData, $retrieveParametersFromServer);
+                if (!$signatureValid) {
                     throw new OneLogin_Saml2_ValidationError(
                         "Signature validation failed. Logout Response rejected",
                         OneLogin_Saml2_ValidationError::INVALID_SIGNATURE
@@ -262,6 +221,7 @@ class OneLogin_Saml2_LogoutResponse
         $this->id = OneLogin_Saml2_Utils::generateUniqueID();
         $issueInstant = OneLogin_Saml2_Utils::parseTime2SAML(time());
 
+        $sp_entity_id = htmlspecialchars($spData['entityId'], ENT_QUOTES);
         $logoutResponse = <<<LOGOUTRESPONSE
 <samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
                   xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -271,7 +231,7 @@ class OneLogin_Saml2_LogoutResponse
                   Destination="{$idpData['singleLogoutService']['url']}"
                   InResponseTo="{$inResponseTo}"
                   >
-    <saml:Issuer>{$spData['entityId']}</saml:Issuer>
+    <saml:Issuer>{$sp_entity_id}</saml:Issuer>
     <samlp:Status>
         <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
     </samlp:Status>

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Metadata.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Metadata.php
@@ -38,9 +38,10 @@ class OneLogin_Saml2_Metadata
         $sls = '';
 
         if (isset($sp['singleLogoutService'])) {
+            $sls_url = htmlspecialchars($sp['singleLogoutService']['url'], ENT_QUOTES);
             $sls = <<<SLS_TEMPLATE
         <md:SingleLogoutService Binding="{$sp['singleLogoutService']['binding']}"
-                                Location="{$sp['singleLogoutService']['url']}" />
+                                Location="{$sls_url}" />
 
 SLS_TEMPLATE;
         }
@@ -127,7 +128,7 @@ CONTACT;
                     $reqAttrAuxStr = '>';
                     if (is_string($attribute['attributeValue'])) {
                         $attribute['attributeValue'] = array($attribute['attributeValue']);
-                    }                    
+                    }
                     foreach ($attribute['attributeValue'] as $attrValue) {
                         $reqAttrAuxStr .=<<<ATTRIBUTEVALUE
 
@@ -149,16 +150,18 @@ ATTRIBUTEVALUE;
 METADATA_TEMPLATE;
         }
 
+        $sp_entity_id = htmlspecialchars($sp['entityId'], ENT_QUOTES);
+        $acs_url = htmlspecialchars($sp['assertionConsumerService']['url'], ENT_QUOTES);
         $metadata = <<<METADATA_TEMPLATE
 <?xml version="1.0"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
                      validUntil="{$validUntilTime}"
                      cacheDuration="PT{$cacheDuration}S"
-                     entityID="{$sp['entityId']}">
+                     entityID="{$sp_entity_id}">
     <md:SPSSODescriptor AuthnRequestsSigned="{$strAuthnsign}" WantAssertionsSigned="{$strWsign}" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 {$sls}        <md:NameIDFormat>{$sp['NameIDFormat']}</md:NameIDFormat>
         <md:AssertionConsumerService Binding="{$sp['assertionConsumerService']['binding']}"
-                                     Location="{$sp['assertionConsumerService']['url']}"
+                                     Location="{$acs_url}"
                                      index="1" />
         {$strAttributeConsumingService}
     </md:SPSSODescriptor>{$strOrganization}{$strContacts}

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Response.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Response.php
@@ -373,8 +373,15 @@ class OneLogin_Saml2_Response
                 $fingerprint = $idpData['certFingerprint'];
                 $fingerprintalg = $idpData['certFingerprintAlgorithm'];
 
+                $multiCerts = null;
+                $existsMultiX509Sign = isset($idpData['x509certMulti']) && isset($idpData['x509certMulti']['signing']) && !empty($idpData['x509certMulti']['signing']);
+
+                if ($existsMultiX509Sign) {
+                    $multiCerts = $idpData['x509certMulti']['signing'];
+                }
+
                 # If find a Signature on the Response, validates it checking the original response
-                if ($hasSignedResponse && !OneLogin_Saml2_Utils::validateSign($this->document, $cert, $fingerprint, $fingerprintalg, OneLogin_Saml2_Utils::RESPONSE_SIGNATURE_XPATH)) {
+                if ($hasSignedResponse && !OneLogin_Saml2_Utils::validateSign($this->document, $cert, $fingerprint, $fingerprintalg, OneLogin_Saml2_Utils::RESPONSE_SIGNATURE_XPATH, $multiCerts)) {
                     throw new OneLogin_Saml2_ValidationError(
                         "Signature validation failed. SAML Response rejected",
                         OneLogin_Saml2_ValidationError::INVALID_SIGNATURE
@@ -383,7 +390,7 @@ class OneLogin_Saml2_Response
 
                 # If find a Signature on the Assertion (decrypted assertion if was encrypted)
                 $documentToCheckAssertion = $this->encrypted ? $this->decryptedDocument : $this->document;
-                if ($hasSignedAssertion && !OneLogin_Saml2_Utils::validateSign($documentToCheckAssertion, $cert, $fingerprint, $fingerprintalg, OneLogin_Saml2_Utils::ASSERTION_SIGNATURE_XPATH)) {
+                if ($hasSignedAssertion && !OneLogin_Saml2_Utils::validateSign($documentToCheckAssertion, $cert, $fingerprint, $fingerprintalg, OneLogin_Saml2_Utils::ASSERTION_SIGNATURE_XPATH, $multiCerts)) {
                     throw new OneLogin_Saml2_ValidationError(
                         "Signature validation failed. SAML Response rejected",
                         OneLogin_Saml2_ValidationError::INVALID_SIGNATURE
@@ -1004,7 +1011,7 @@ class OneLogin_Saml2_Response
                 OneLogin_Saml2_Error::PRIVATE_KEY_NOT_FOUND
             );
         }
-        
+
         $objenc = new XMLSecEnc();
         $encData = $objenc->locateEncryptedData($dom);
         if (!$encData) {
@@ -1013,7 +1020,7 @@ class OneLogin_Saml2_Response
                 OneLogin_Saml2_ValidationError::MISSING_ENCRYPTED_ELEMENT
             );
         }
-        
+
         $objenc->setNode($encData);
         $objenc->type = $encData->getAttribute("Type");
         if (!$objKey = $objenc->locateKey()) {

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Settings.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Settings.php
@@ -17,7 +17,7 @@ class OneLogin_Saml2_Settings
     /**
      * @var string
      */
-    private  $_baseurl;
+    private $_baseurl;
 
     /**
      * Strict. If active, PHP Toolkit will reject unsigned or unencrypted messages
@@ -143,6 +143,8 @@ class OneLogin_Saml2_Settings
         $this->formatIdPCert();
         $this->formatSPCert();
         $this->formatSPKey();
+        $this->formatSPCertNew();
+        $this->formatIdPCertMulti();
     }
 
     /**
@@ -465,14 +467,12 @@ class OneLogin_Saml2_Settings
         if (isset($settings['compress'])) {
             if (!is_array($settings['compress'])) {
                 $errors[] = "invalid_syntax";
-            } else if (
-                isset($settings['compress']['requests'])
+            } else if (isset($settings['compress']['requests'])
                 && $settings['compress']['requests'] !== true
                 && $settings['compress']['requests'] !== false
             ) {
                 $errors[] = "'compress'=>'requests' values must be true or false.";
-            } else if (
-                isset($settings['compress']['responses'])
+            } else if (isset($settings['compress']['responses'])
                 && $settings['compress']['responses'] !== true
                 && $settings['compress']['responses'] !== false
             ) {
@@ -528,15 +528,16 @@ class OneLogin_Saml2_Settings
                 $security = $settings['security'];
 
                 $existsX509 = isset($idp['x509cert']) && !empty($idp['x509cert']);
+                $existsMultiX509Sign = isset($idp['x509certMulti']) && isset($idp['x509certMulti']['signing']) && !empty($idp['x509certMulti']['signing']);
+                $existsMultiX509Enc = isset($idp['x509certMulti']) && isset($idp['x509certMulti']['encryption']) && !empty($idp['x509certMulti']['encryption']);
+
                 $existsFingerprint = isset($idp['certFingerprint']) && !empty($idp['certFingerprint']);
-                if (((isset($security['wantAssertionsSigned']) && $security['wantAssertionsSigned'] == true)
-                    || (isset($security['wantMessagesSigned']) && $security['wantMessagesSigned'] == true))
-                    && !($existsX509 || $existsFingerprint)
+                if (!($existsX509 || $existsFingerprint || $existsMultiX509Sign)
                 ) {
                     $errors[] = 'idp_cert_or_fingerprint_not_found_and_required';
                 }
                 if ((isset($security['nameIdEncrypted']) && $security['nameIdEncrypted'] == true)
-                    && !($existsX509)
+                    && !($existsX509 || $existsMultiX509Enc)
                 ) {
                     $errors[] = 'idp_cert_not_found_and_required';
                 }
@@ -700,6 +701,28 @@ class OneLogin_Saml2_Settings
     }
 
     /**
+     * Returns the x509 public of the SP that is
+     * planed to be used soon instead the other
+     * public cert
+     * @return string SP public cert New
+     */
+    public function getSPcertNew()
+    {
+        $cert = null;
+
+        if (isset($this->_sp['x509certNew']) && !empty($this->_sp['x509certNew'])) {
+            $cert = $this->_sp['x509certNew'];
+        } else {
+            $certFile = $this->_paths['cert'].'sp_new.crt';
+
+            if (file_exists($certFile)) {
+                $cert = file_get_contents($certFile);
+            }
+        }
+        return $cert;
+    }
+
+    /**
      * Gets the IdP data.
      *
      * @return array  IdP info
@@ -780,8 +803,16 @@ class OneLogin_Saml2_Settings
     {
         $metadata = OneLogin_Saml2_Metadata::builder($this->_sp, $this->_security['authnRequestsSigned'], $this->_security['wantAssertionsSigned'], null, null, $this->getContacts(), $this->getOrganization());
 
-        $cert = $this->getSPcert();
+        $certNew = $this->getSPcertNew();
+        if (!empty($certNew)) {
+            $metadata = OneLogin_Saml2_Metadata::addX509KeyDescriptors(
+                $metadata,
+                $certNew,
+                $this->_security['wantNameIdEncrypted'] || $this->_security['wantAssertionsEncrypted']
+            );
+        }
 
+        $cert = $this->getSPcert();
         if (!empty($cert)) {
             $metadata = OneLogin_Saml2_Metadata::addX509KeyDescriptors(
                 $metadata,
@@ -904,12 +935,41 @@ class OneLogin_Saml2_Settings
     }
 
     /**
+     * Formats the Multple IdP certs.
+     */
+    public function formatIdPCertMulti()
+    {
+        if (isset($this->_idp['x509certMulti'])) {
+            if (isset($this->_idp['x509certMulti']['signing'])) {
+                for ($i=0; $i < count($this->_idp['x509certMulti']['signing']); $i++) {
+                    $this->_idp['x509certMulti']['signing'][$i] = OneLogin_Saml2_Utils::formatCert($this->_idp['x509certMulti']['signing'][$i]);
+                }
+            }
+            if (isset($this->_idp['x509certMulti']['encryption'])) {
+                for ($i=0; $i < count($this->_idp['x509certMulti']['encryption']); $i++) {
+                    $this->_idp['x509certMulti']['encryption'][$i] = OneLogin_Saml2_Utils::formatCert($this->_idp['x509certMulti']['encryption'][$i]);
+                }
+            }
+        }
+    }
+
+    /**
      * Formats the SP cert.
      */
     public function formatSPCert()
     {
         if (isset($this->_sp['x509cert'])) {
             $this->_sp['x509cert'] = OneLogin_Saml2_Utils::formatCert($this->_sp['x509cert']);
+        }
+    }
+
+    /**
+     * Formats the SP cert.
+     */
+    public function formatSPCertNew()
+    {
+        if (isset($this->_sp['x509certNew'])) {
+            $this->_sp['x509certNew'] = OneLogin_Saml2_Utils::formatCert($this->_sp['x509certNew']);
         }
     }
 
@@ -992,7 +1052,7 @@ class OneLogin_Saml2_Settings
      */
     public function setIdPCert($cert)
     {
-      $this->_idp['x509cert'] = $cert;
-      $this->formatIdPCert();
+        $this->_idp['x509cert'] = $cert;
+        $this->formatIdPCert();
     }
 }

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Utils.php
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/Utils.php
@@ -129,7 +129,6 @@ class OneLogin_Saml2_Utils
         $res = $dom->schemaValidate($schemaFile);
         libxml_disable_entity_loader($oldEntityLoader);
         if (!$res) {
-
             $xmlErrors = libxml_get_errors();
             syslog(LOG_INFO, 'Error validating the metadata: '.var_export($xmlErrors, true));
 
@@ -184,16 +183,15 @@ class OneLogin_Saml2_Utils
     {
         $key = str_replace(array("\x0D", "\r", "\n"), "", $key);
         if (!empty($key)) {
-
             if (strpos($key, '-----BEGIN PRIVATE KEY-----') !== false) {
-                $key = OneLogin_Saml2_Utils::get_string_between($key, '-----BEGIN PRIVATE KEY-----', '-----END PRIVATE KEY-----');
+                $key = OneLogin_Saml2_Utils::getStringBetween($key, '-----BEGIN PRIVATE KEY-----', '-----END PRIVATE KEY-----');
                 $key = str_replace(' ', '', $key);
 
                 if ($heads) {
                     $key = "-----BEGIN PRIVATE KEY-----\n".chunk_split($key, 64, "\n")."-----END PRIVATE KEY-----\n";
                 }
             } else if (strpos($key, '-----BEGIN RSA PRIVATE KEY-----') !== false) {
-                $key = OneLogin_Saml2_Utils::get_string_between($key, '-----BEGIN RSA PRIVATE KEY-----', '-----END RSA PRIVATE KEY-----');
+                $key = OneLogin_Saml2_Utils::getStringBetween($key, '-----BEGIN RSA PRIVATE KEY-----', '-----END RSA PRIVATE KEY-----');
                 $key = str_replace(' ', '', $key);
 
                 if ($heads) {
@@ -220,7 +218,7 @@ class OneLogin_Saml2_Utils
      * @return string A substring or an empty string if is not able to find the marks
      *                or if there is no string between the marks
      */
-    public static function get_string_between($str, $start, $end)
+    public static function getStringBetween($str, $start, $end)
     {
         $str = ' ' . $str;
         $ini = strpos($str, $start);
@@ -271,7 +269,6 @@ class OneLogin_Saml2_Utils
         }
 
         foreach ($parameters as $name => $value) {
-
             if ($value === null) {
                 $param = urlencode($name);
             } else if (is_array($value)) {
@@ -334,6 +331,11 @@ class OneLogin_Saml2_Utils
                 self::setSelfPort($port);
                 self::setBaseURLPath($baseurlpath);
             }
+        } else {
+                self::$_host = null;
+                self::$_protocol = null;
+                self::$_port = null;
+                self::$_baseurlpath = null;
         }
     }
 
@@ -393,8 +395,10 @@ class OneLogin_Saml2_Utils
      */
     public static function setBaseURLPath($baseurlpath)
     {
-        if (empty($baseurlpath) || $baseurlpath == '/') {
-            $baseurlpath = '/';
+        if (empty($baseurlpath)) {
+            self::$_baseurlpath = null;
+        } else if ($baseurlpath == '/') {
+            self::$_baseurlpath = '/';
         } else {
             self::$_baseurlpath = '/' . trim($baseurlpath, '/') . '/';
         }
@@ -614,7 +618,7 @@ class OneLogin_Saml2_Utils
                 if (!empty($extractedInfo)) {
                     $result .= $extractedInfo;
                 }
-            } 
+            }
         }
         return $result;
     }
@@ -626,7 +630,7 @@ class OneLogin_Saml2_Utils
      *
      * @return string
      */
-    public static function extractOriginalQueryParam ($name)
+    public static function extractOriginalQueryParam($name)
     {
         $index = strpos($_SERVER['QUERY_STRING'], $name.'=');
         $substring = substr($_SERVER['QUERY_STRING'], $index + strlen($name) + 1);
@@ -828,7 +832,7 @@ class OneLogin_Saml2_Utils
      *
      * @param DOMDocument $dom     The DOMDocument
      * @param string      $query   Xpath Expresion
-     * @param DomElement  $context Context Node (DomElement) 
+     * @param DomElement  $context Context Node (DomElement)
      *
      * @return DOMNodeList The queried nodes
      */
@@ -839,6 +843,9 @@ class OneLogin_Saml2_Utils
         $xpath->registerNamespace('saml', OneLogin_Saml2_Constants::NS_SAML);
         $xpath->registerNamespace('ds', OneLogin_Saml2_Constants::NS_DS);
         $xpath->registerNamespace('xenc', OneLogin_Saml2_Constants::NS_XENC);
+        $xpath->registerNamespace('xsi', OneLogin_Saml2_Constants::NS_XSI);
+        $xpath->registerNamespace('xs', OneLogin_Saml2_Constants::NS_XS);
+        $xpath->registerNamespace('md', OneLogin_Saml2_Constants::NS_MD);
 
         if (isset($context)) {
             $res = $xpath->query($query, $context);
@@ -882,7 +889,7 @@ class OneLogin_Saml2_Utils
      *
      * @return null|string Formatted fingerprint
      */
-    public static function calculateX509Fingerprint($x509cert, $alg='sha1')
+    public static function calculateX509Fingerprint($x509cert, $alg = 'sha1')
     {
         assert('is_string($x509cert)');
 
@@ -913,7 +920,7 @@ class OneLogin_Saml2_Utils
             case 'sha512':
             case 'sha384':
             case 'sha256':
-                $fingerprint = hash($alg, $decodedData, FALSE);
+                $fingerprint = hash($alg, $decodedData, false);
                 break;
             case 'sha1':
             default:
@@ -1095,7 +1102,7 @@ class OneLogin_Saml2_Utils
                 // To protect against "key oracle" attacks
                 throw new OneLogin_Saml2_ValidationError(
                     'Unknown key size for encryption algorithm: ' . var_export($symmetricKey->type, true),
-                    OneLogin_Saml2_ValidationError::KEY_ALGORITHM_ERROR                                        
+                    OneLogin_Saml2_ValidationError::KEY_ALGORITHM_ERROR
                 );
             }
 
@@ -1121,7 +1128,7 @@ class OneLogin_Saml2_Utils
                     'Algorithm mismatch between input key and key in message. ' .
                     'Key was: ' . var_export($inputKeyAlgo, true) . '; message was: ' .
                     var_export($symKeyAlgo, true),
-                    OneLogin_Saml2_ValidationError::KEY_ALGORITHM_ERROR                                        
+                    OneLogin_Saml2_ValidationError::KEY_ALGORITHM_ERROR
                 );
             }
             $symmetricKey = $inputKey;
@@ -1137,7 +1144,7 @@ class OneLogin_Saml2_Utils
         if (!$newDoc) {
             throw new OneLogin_Saml2_ValidationError(
                 'Failed to parse decrypted XML.',
-                OneLogin_Saml2_ValidationError::INVALID_XML_FORMAT                                        
+                OneLogin_Saml2_ValidationError::INVALID_XML_FORMAT
             );
         }
  
@@ -1145,7 +1152,7 @@ class OneLogin_Saml2_Utils
         if ($decryptedElement === null) {
             throw new OneLogin_Saml2_ValidationError(
                 'Missing encrypted element.',
-                OneLogin_Saml2_ValidationError::MISSING_ENCRYPTED_ELEMENT                                        
+                OneLogin_Saml2_ValidationError::MISSING_ENCRYPTED_ELEMENT
             );
         }
 
@@ -1257,12 +1264,13 @@ class OneLogin_Saml2_Utils
      * @param string|null    $fingerprint    The fingerprint of the public cert
      * @param string|null    $fingerprintalg The algorithm used to get the fingerprint
      * @param string|null    $xpath          The xpath of the signed element
+     * @param array|null     $multiCerts     Multiple public certs
      *
      * @return bool
      *
      * @throws Exception
      */
-    public static function validateSign($xml, $cert = null, $fingerprint = null, $fingerprintalg = 'sha1', $xpath=null)
+    public static function validateSign($xml, $cert = null, $fingerprint = null, $fingerprintalg = 'sha1', $xpath = null, $multiCerts = null)
     {
         if ($xml instanceof DOMDocument) {
             $dom = clone $xml;
@@ -1303,18 +1311,108 @@ class OneLogin_Saml2_Utils
 
         XMLSecEnc::staticLocateKeyInfo($objKey, $objDSig);
 
-        if (!empty($cert)) {
-            $objKey->loadKey($cert, false, true);
-            return ($objXMLSecDSig->verify($objKey) === 1);
+        if (!empty($multiCerts)) {
+            // If multiple certs are provided, I may ignore $cert and
+            // $fingerprint provided by the method and just check the
+            // certs on the array
+            $fingerprint = null;
         } else {
-            $domCert = $objKey->getX509Certificate();
-            $domCertFingerprint = OneLogin_Saml2_Utils::calculateX509Fingerprint($domCert, $fingerprintalg);
-            if (OneLogin_Saml2_Utils::formatFingerPrint($fingerprint) !== $domCertFingerprint) {
-                return false;
+            // else I add the cert to the array in order to check
+            // validate signatures with it and the with it and the
+            // $fingerprint value
+            $multiCerts = array($cert);
+        }
+
+        $valid = false;
+        foreach ($multiCerts as $cert) {
+            if (!empty($cert)) {
+                $objKey->loadKey($cert, false, true);
+                if ($objXMLSecDSig->verify($objKey) === 1) {
+                    $valid = true;
+                    break;
+                }
             } else {
-                $objKey->loadKey($domCert, false, true);
-                return ($objXMLSecDSig->verify($objKey) === 1);
+                if (!empty($fingerprint)) {
+                    $domCert = $objKey->getX509Certificate();
+                    $domCertFingerprint = OneLogin_Saml2_Utils::calculateX509Fingerprint($domCert, $fingerprintalg);
+                    if (OneLogin_Saml2_Utils::formatFingerPrint($fingerprint) == $domCertFingerprint) {
+                        $objKey->loadKey($domCert, false, true);
+                        if ($objXMLSecDSig->verify($objKey) === 1) {
+                            $valid = true;
+                            break;
+                        }
+                    }
+                }
             }
         }
+        return $valid;
+    }
+
+    public static function validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer = false)
+    {
+        if (!isset($getData['SigAlg'])) {
+            $signAlg = XMLSecurityKey::RSA_SHA1;
+        } else {
+            $signAlg = $getData['SigAlg'];
+        }
+
+        if ($retrieveParametersFromServer) {
+            $signedQuery = $messageType.'='.OneLogin_Saml2_Utils::extractOriginalQueryParam($messageType);
+            if (isset($getData['RelayState'])) {
+                $signedQuery .= '&RelayState='.OneLogin_Saml2_Utils::extractOriginalQueryParam('RelayState');
+            }
+            $signedQuery .= '&SigAlg='.OneLogin_Saml2_Utils::extractOriginalQueryParam('SigAlg');
+        } else {
+            $signedQuery = $messageType.'='.urlencode($getData[$messageType]);
+            if (isset($getData['RelayState'])) {
+                $signedQuery .= '&RelayState='.urlencode($getData['RelayState']);
+            }
+            $signedQuery .= '&SigAlg='.urlencode($signAlg);
+        }
+
+        if ($messageType == "SAMLRequest") {
+            $strMessageType = "Logout Request";
+        } else {
+            $strMessageType = "Logout Response";
+        }
+        $existsMultiX509Sign = isset($idpData['x509certMulti']) && isset($idpData['x509certMulti']['signing']) && !empty($idpData['x509certMulti']['signing']);
+        if ((!isset($idpData['x509cert']) || empty($idpData['x509cert'])) && !$existsMultiX509Sign) {
+            throw new OneLogin_Saml2_Error(
+                "In order to validate the sign on the ".$strMessageType.", the x509cert of the IdP is required",
+                OneLogin_Saml2_Error::CERT_NOT_FOUND
+            );
+        }
+
+        if ($existsMultiX509Sign) {
+            $multiCerts = $idpData['x509certMulti']['signing'];
+        } else {
+            $multiCerts = array($idpData['x509cert']);
+        }
+
+        $signatureValid = false;
+        foreach ($multiCerts as $cert) {
+            $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' => 'public'));
+            $objKey->loadKey($cert, false, true);
+
+            if ($signAlg != XMLSecurityKey::RSA_SHA1) {
+                try {
+                    $objKey = OneLogin_Saml2_Utils::castKey($objKey, $signAlg, 'public');
+                } catch (Exception $e) {
+                    $ex = new OneLogin_Saml2_ValidationError(
+                        "Invalid signAlg in the recieved ".$strMessageType,
+                        OneLogin_Saml2_ValidationError::INVALID_SIGNATURE
+                    );
+                    if (count($multiCerts) == 1) {
+                        throw $ex;
+                    }
+                }
+            }
+
+            if ($objKey->verifySignature($signedQuery, base64_decode($_GET['Signature'])) === 1) {
+                $signatureValid = true;
+                break;
+            }
+        }
+        return $signatureValid;
     }
 }

--- a/3rdparty/vendor/onelogin/php-saml/lib/Saml2/version.json
+++ b/3rdparty/vendor/onelogin/php-saml/lib/Saml2/version.json
@@ -1,6 +1,6 @@
 {
     "php-saml": {
-        "version": "2.10.5",
-        "released": "13/03/2017"
+        "version": "2.10.7",
+        "released": "19/05/2017"
     }
 }

--- a/3rdparty/vendor/onelogin/php-saml/settings_example.php
+++ b/3rdparty/vendor/onelogin/php-saml/settings_example.php
@@ -10,10 +10,10 @@ $settings = array (
     // Enable debug mode (to print errors)
     'debug' => false,
 
-    // Set a BaseURL to be used instead of try to guess 
+    // Set a BaseURL to be used instead of try to guess
     // the BaseURL of the view that process the SAML Message.
     // Ex. http://sp.example.com/
-    //     http://example.com/sp/ 
+    //     http://example.com/sp/
     'baseurl' => null,
 
     // Service Provider Data that we are deploying
@@ -32,7 +32,7 @@ $settings = array (
         ),
         // If you need to specify requested attributes, set a
         // attributeConsumingService. nameFormat, attributeValue and
-        // friendlyName can be omitted. Otherwise remove this section. 
+        // friendlyName can be omitted. Otherwise remove this section.
         "attributeConsumingService"=> array(
                 "ServiceName" => "SP test",
                 "serviceDescription" => "Test Service",
@@ -65,6 +65,15 @@ $settings = array (
         // the certs folder. But we can also provide them with the following parameters
         'x509cert' => '',
         'privateKey' => '',
+
+        /*
+         * Key rollover
+         * If you plan to update the SP x509cert and privateKey
+         * you can define here the new x509cert and it will be 
+         * published on the SP metadata so Identity Providers can
+         * read them and get ready for rollover.
+         */
+        // 'x509certNew' => '',
     ),
 
     // Identity Provider Data that we want connect with our SP
@@ -102,5 +111,21 @@ $settings = array (
          */
         // 'certFingerprint' => '',
         // 'certFingerprintAlgorithm' => 'sha1',
+
+        /* In some scenarios the IdP uses different certificates for
+         * signing/encryption, or is under key rollover phase and more 
+         * than one certificate is published on IdP metadata.
+         * In order to handle that the toolkit offers that parameter.
+         * (when used, 'x509cert' and 'certFingerprint' values are
+         * ignored).
+         */
+        // 'x509certMulti' => array(
+        //      'signing' => array(
+        //          0 => '<cert1-string>',
+        //      ),
+        //      'encryption' => array(
+        //          0 => '<cert2-string>',
+        //      )
+        // ),
     ),
 );

--- a/lib/samlsettings.php
+++ b/lib/samlsettings.php
@@ -94,13 +94,13 @@ class SAMLSettings {
 
 		$idpmetadataXml = $this->config->getAppValue('user_saml', 'idp-metadata.xml', '');
 		if($idpmetadataXml !== '') {
-			$idpmetadataParsed = \OneLogin_Saml2_IdPMetadataParser::parseXML($idpmetadataXml, $settings['idp']['entityId']);
+			$idpmetadataParsed = \OneLogin_Saml2_IdPMetadataParser::parseXML($idpmetadataXml, $this->config->getAppValue('user_saml', 'idp-entityId'));
 			$settings = \OneLogin_Saml2_IdPMetadataParser::injectIntoSettings($settings, $idpmetadataParsed);
 		}
 
 		$idpmetadataUrl = $this->config->getAppValue('user_saml', 'idp-metadata.url', '');
 		if($idpmetadataUrl !== '') {
-			$idpmetadataParsed = \OneLogin_Saml2_IdPMetadataParser::parseRemoteXML($idpmetadataUrl, $settings['idp']['entityId']);
+			$idpmetadataParsed = \OneLogin_Saml2_IdPMetadataParser::parseRemoteXML($idpmetadataUrl, $this->config->getAppValue('user_saml', 'idp-entityId'));
 			$settings = \OneLogin_Saml2_IdPMetadataParser::injectIntoSettings($settings, $idpmetadataParsed);
 		}
 

--- a/lib/samlsettings.php
+++ b/lib/samlsettings.php
@@ -66,12 +66,6 @@ class SAMLSettings {
 					'url' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.assertionConsumerService'),
 				],
 			],
-			'idp' => [
-				'entityId' => $this->config->getAppValue('user_saml', 'idp-entityId', ''),
-				'singleSignOnService' => [
-					'url' => $this->config->getAppValue('user_saml', 'idp-singleSignOnService.url', ''),
-				],
-			],
 		];
 
 		$spx509cert = $this->config->getAppValue('user_saml', 'sp-x509cert', '');
@@ -96,6 +90,28 @@ class SAMLSettings {
 			$settings['sp']['singleLogoutService'] = [
 				'url' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.singleLogoutService'),
 			];
+		}
+
+		$idpmetadataXml = $this->config->getAppValue('user_saml', 'idp-metadata.xml', '');
+		if($idpmetadataXml !== '') {
+			$idpmetadataParsed = \OneLogin_Saml2_IdPMetadataParser::parseXML($idpmetadataXml, $settings['idp']['entityId']);
+			$settings = \OneLogin_Saml2_IdPMetadataParser::injectIntoSettings($settings, $idpmetadataParsed);
+		}
+
+		$idpmetadataUrl = $this->config->getAppValue('user_saml', 'idp-metadata.url', '');
+		if($idpmetadataUrl !== '') {
+			$idpmetadataParsed = \OneLogin_Saml2_IdPMetadataParser::parseRemoteXML($idpmetadataUrl, $settings['idp']['entityId']);
+			$settings = \OneLogin_Saml2_IdPMetadataParser::injectIntoSettings($settings, $idpmetadataParsed);
+		}
+
+		$idpentityId = $this->config->getAppValue('user_saml', 'idp-entityId', '');
+		if($idpentityId !== '') {
+			$settings['idp']['entityId'] = $idpentityId;
+		}
+
+		$idpssoUrl = $this->config->getAppValue('user_saml', 'idp-singleSignOnService.url', '');
+		if($idpssoUrl !== '') {
+			$settings['idp']['singleSignOnService']['url'] = $idpssoUrl;
 		}
 
 		return $settings;

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -77,6 +77,8 @@ style('user_saml', 'admin');
 			<div class="hidden">
 				<p><input name="singleLogoutService.url" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-singleLogoutService.url', '')) ?>" type="text" placeholder="<?php p($l->t('URL Location of the IdP where the SP will send the SLO Request')) ?>"/></p>
 				<p><textarea name="x509cert" placeholder="<?php p($l->t('Public X.509 certificate of the IdP')) ?>"><?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-x509cert', '')) ?></textarea></p>
+                <p><input name="metadata.url" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-metadata.url', '')) ?>" type="text" placeholder="<?php p($l->t('URL Location of the IdP metadata')) ?>"/></p>
+                <p><textarea name="metadata.xml" placeholder="<?php p($l->t('XML metadata for IdP')) ?>"><?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-metadata.xml', '')) ?></textarea></p>
 			</div>
 		</div>
 


### PR DESCRIPTION
This enhances the SAML plugin with the ability to provide IdP metadata XML, reducing the amount of configuration required in certain environments.

Changes:
- Update php-saml to 2.10.7 (IdP metadata parsing was added in 2.10.6)
- Add config values to the admin interface to support either pasting XML or URL to IdP metadata.

Implementation details:
- If a user provides both a URL and XML, the XML will be parsed and injected, followed by the metadata from the URL. This way the metadata provided by the IdP takes precedence and things like certificates should be kept up to date automatically.
- If the user specifies the IdP Entity ID or SSO URL, these will take precedence over values received from metadata.
- If the user specifies the IdP Entity ID, it must match the IdP metadata else the metadata is ignored.

Opportunities for improvement:
- Cache metadata in case URL becomes unavailable (since metadata is typically delivered by same IdP server that would handle the SAML request, this is probably generally moot.)
- Populate admin interface with values parsed from metadata to more clearly indicate to Nextcloud admin what exactly is being set by the metadata.

Tested with Okta.