### PR TITLE
Fix warnings from userbackend.php

### DIFF
--- a/lib/userbackend.php
+++ b/lib/userbackend.php
@@ -391,9 +391,11 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 	 * @return null|UserInterface
 	 */
 	public function getActualUserBackend($uid) {
-		foreach($this->backends as $backend) {
-			if($backend->userExists($uid)) {
-				return $backend;
+		if($this->backends !== null) {
+			foreach ( $this->backends as $backend ) {
+				if ( $backend->userExists( $uid ) ) {
+					return $backend;
+				}
 			}
 		}
 

--- a/lib/userbackend.php
+++ b/lib/userbackend.php
@@ -415,7 +415,7 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 	private function getAttributeValue($name, array $attributes) {
 		$keys = explode(' ', $this->config->getAppValue('user_saml', $name, ''));
 
-		if(count($keys) === 1 && $keys[1] === '') {
+		if(count($keys) === 1 && $keys[0] === '') {
 			throw new \InvalidArgumentException('Attribute is not configured');
 		}
 


### PR DESCRIPTION
Warnings were being logged, which this PR resolves.

`{"reqId":"lIu5pnMbrx0DQWD7j7Lc","level":3,"time":"2017-07-14T23:59:09+00:00","remoteAddr":"172.20.0.1","user":"--","app":"PHP","method":"POST","url":"\/index.php\/apps\/user_saml\/saml\/acs","message":"Undefined offset: 1 at \/var\/www\/html\/custom_apps\/user_saml\/lib\/UserBackend.php#416","userAgent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/59.0.3071.115 Safari\/537.36","version":"12.0.0.29"}`

`{"reqId":"lIu5pnMbrx0DQWD7j7Lc","level":3,"time":"2017-07-14T23:59:09+00:00","remoteAddr":"172.20.0.1","user":"--","app":"PHP","method":"POST","url":"\/index.php\/apps\/user_saml\/saml\/acs","message":"Invalid argument supplied for foreach() at \/var\/www\/html\/custom_apps\/user_saml\/lib\/UserBackend.php#394","userAgent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/59.0.3071.115 Safari\/537.36","version":"12.0.0.29"}`