### PR TITLE
Add baseurl to SAML settings

### DIFF
--- a/lib/samlsettings.php
+++ b/lib/samlsettings.php
@@ -45,6 +45,7 @@ class SAMLSettings {
 		$settings = [
 			'strict' => true,
 			'debug' => $this->config->getSystemValue('debug', false),
+			'baseurl' => $this->urlGenerator->getAbsoluteURL('/'),
 			'security' => [
 				'nameIdEncrypted' => ($this->config->getAppValue('user_saml', 'security-nameIdEncrypted', '0') === '1') ? true : false,
 				'authnRequestsSigned' => ($this->config->getAppValue('user_saml', 'security-authnRequestsSigned', '0') === '1') ? true : false,


### PR DESCRIPTION
In case the protected server is behind reverse proxies with a different protocol this is required.

Fixes https://github.com/nextcloud/user_saml/issues/120

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>