### PR TITLE
Add a URL to logout the user

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -44,6 +44,11 @@ return [
 			'verb' => 'GET',
 		],
 		[
+			'name' => 'SAML#singleSignOut',
+			'url' => '/saml/signOut',
+			'verb' => 'POST',
+		],
+		[
 			'name' => 'SAML#notProvisioned',
 			'url' => '/saml/notProvisioned',
 			'verb' => 'GET',

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -78,7 +78,8 @@ class Admin implements ISettings {
 		];
 		$generalSettings = [
 			'uid_mapping' => [
-				'text' => $this->l10n->t('Attribute to map the UID to.'),
+				'text' => 'User.LastName',
+				'label' => $this->l10n->t('Attribute to map the UID to.'),
 				'type' => 'line',
 				'required' => true,
 			],
@@ -89,12 +90,14 @@ class Admin implements ISettings {
 		];
 		$attributeMappingSettings = [
 			'displayName_mapping' => [
-				'text' => $this->l10n->t('Attribute to map the displayname to.'),
+				'text' => 'User.FirstName User.LastName',
+				'label' => $this->l10n->t('Attribute to map the displayname to.'),
 				'type' => 'line',
 				'required' => true,
 			],
 			'email_mapping' => [
-				'text' => $this->l10n->t('Attribute to map the email address to.'),
+				'text' =>'User.Email',
+				'label' => $this->l10n->t('Attribute to map the email address to.'),
 				'type' => 'line',
 				'required' => true,
 			],
@@ -105,6 +108,11 @@ class Admin implements ISettings {
 			$generalSettings['use_saml_auth_for_desktop'] = [
 				'text' => $this->l10n->t('Use SAML auth for the %s desktop clients (requires user re-authentication)', [$this->defaults->getName()]),
 				'type' => 'checkbox',
+			];
+			$generalSettings['sign_out_secret'] = [
+				'text' => $this->l10n->t('Shared secret'),
+				'label' => $this->l10n->t('Shared secret to enable endpoint to logout all temporary sessions of a user'),
+				'type' => 'line',
 			];
 		}
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -43,6 +43,7 @@ style('user_saml', 'admin');
 				<?php elseif($attribute['type'] === 'line'): ?>
 					<p>
 						<input name="<?php p($key) ?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '')) ?>" type="text" <?php if(isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
+						<?php if (isset($attribute['label'])) { ?><br><em><?php p($attribute['label']); ?></em><?php } ?>
 					</p>
 				<?php endif; ?>
 			<?php endforeach; ?>
@@ -71,11 +72,19 @@ style('user_saml', 'admin');
 				<?php print_unescaped($l->t('Configure your IdP settings here.')) ?>
 							</p>
 
-			<p><input name="entityId" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-entityId', '')) ?>" type="text" class="required" placeholder="<?php p($l->t('Identifier of the IdP entity (must be a URI)')) ?>"/></p>
-			<p><input name="singleSignOnService.url" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-singleSignOnService.url', '')) ?>"  type="text" class="required" placeholder="<?php p($l->t('URL Target of the IdP where the SP will send the Authentication Request Message')) ?>"/></p>
+			<p>
+				<input name="entityId" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-entityId', '')) ?>" type="text" class="required" placeholder="https://example.com/saml2"/>
+				<br><em><?php p($l->t('Identifier of the IdP entity (must be a URI)')) ?></em>
+			</p>
+			<p>
+				<input name="singleSignOnService.url" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-singleSignOnService.url', '')) ?>"  type="text" class="required" placeholder="https://example.com/saml2/http-post/sso"/>
+				<br><em><?php p($l->t('URL Target of the IdP where the SP will send the Authentication Request Message')); ?></em>
+			</p>
 			<p><span class="toggle"><?php p($l->t('Show optional Identity Provider settings…')) ?></span></p>
 			<div class="hidden">
-				<p><input name="singleLogoutService.url" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-singleLogoutService.url', '')) ?>" type="text" placeholder="<?php p($l->t('URL Location of the IdP where the SP will send the SLO Request')) ?>"/></p>
+				<p><input name="singleLogoutService.url" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-singleLogoutService.url', '')) ?>" type="text" placeholder="https://example.com/saml2/http-redirect/slo"/>
+					<br><em><?php p($l->t('URL Location of the IdP where the SP will send the SLO Request')); ?></em>
+				</p>
 				<p><textarea name="x509cert" placeholder="<?php p($l->t('Public X.509 certificate of the IdP')) ?>"><?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-x509cert', '')) ?></textarea></p>
 			</div>
 		</div>


### PR DESCRIPTION
Enable `Enable unauthenticated endpoint to logout a user` in the admin UI

Call: `curl -X POST 'https://localhost/index.php/apps/user_saml/saml/signOut' --data 'uid=admin&secret=YourSecret'` and it will kill all temporary sessions, retaining the sync client tokens.