### PR TITLE
Detect disabled user stable13

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ pipeline:
     image: nextcloudci/php5.6:php5.6-3
     environment:
       - APP_NAME=user_saml
-      - CORE_BRANCH=master
+      - CORE_BRANCH=stable13
       - DB=sqlite
     commands:
       # Pre-setup steps
@@ -46,7 +46,7 @@ pipeline:
     image: nextcloudci/php7.0:php7.0-2
     environment:
       - APP_NAME=user_saml
-      - CORE_BRANCH=master
+      - CORE_BRANCH=stable13
       - DB=sqlite
     commands:
       # Pre-setup steps
@@ -61,7 +61,7 @@ pipeline:
     image: nextcloudci/php5.6:php5.6-3
     environment:
       - APP_NAME=user_saml
-      - CORE_BRANCH=master
+      - CORE_BRANCH=stable13
       - DB=sqlite
     commands:
       - apt update && apt-get -y install php5-xdebug
@@ -86,7 +86,7 @@ pipeline:
     image: nextcloudci/php7.0:php7.0-2
     environment:
       - APP_NAME=user_saml
-      - CORE_BRANCH=master
+      - CORE_BRANCH=stable13
       - DB=sqlite
     commands:
       # Pre-setup steps
@@ -104,7 +104,7 @@ pipeline:
     image: nextcloudci/php7.1:php7.1-12
     environment:
       - APP_NAME=user_saml
-      - CORE_BRANCH=master
+      - CORE_BRANCH=stable13
       - DB=sqlite
     commands:
       # Pre-setup steps
@@ -182,7 +182,7 @@ pipeline:
   integration-tests:
     image: nextcloudci/user_saml_shibboleth:user_saml_shibboleth-5
     environment:
-      - CORE_BRANCH=master
+      - CORE_BRANCH=stable13
     commands:
       - /start.sh &
       - sleep 3

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -29,6 +29,7 @@ if(OC::$CLI) {
 }
 
 $urlGenerator = \OC::$server->getURLGenerator();
+$l = \OC::$server->getL10N('user_saml');
 $config = \OC::$server->getConfig();
 $request = \OC::$server->getRequest();
 $userSession = \OC::$server->getUserSession();
@@ -71,6 +72,22 @@ if($returnScript === true) {
 }
 
 $redirectSituation = false;
+
+$user = $userSession->getUser();
+if ($user !== null) {
+	$enabled = $user->isEnabled();
+	if ($enabled === false) {
+		$targetUrl = $urlGenerator->linkToRouteAbsolute(
+			'user_saml.SAML.genericError',
+			[
+				'message' => $l->t('This user account is disabled, please contact your administrator.')
+			]
+		);
+		header('Location: '.$targetUrl);
+		exit();
+	}
+}
+
 // All requests that are not authenticated and match against the "/login" route are
 // redirected to the SAML login endpoint
 if(!$cli &&

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -48,5 +48,10 @@ return [
 			'url' => '/saml/notProvisioned',
 			'verb' => 'GET',
 		],
+		[
+			'name' => 'SAML#genericError',
+			'url' => '/saml/error',
+			'verb' => 'GET',
+		],
 	],
 ];

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -99,6 +99,12 @@ class SAMLController extends Controller {
 				$uid = $auth[$uidMapping];
 			}
 
+			// make sure that a valid UID is given
+			if (empty($uid)) {
+				$this->logger->error('Uid "' . $uid . '" is not a valid uid please check your attribute mapping', ['app' => $this->appName]);
+				throw new \InvalidArgumentException('No valid uid given, please check your attribute mapping. Given uid: ' . $uid);
+			}
+
 			$userExists = $this->userManager->userExists($uid);
 			$autoProvisioningAllowed = $this->userBackend->autoprovisionAllowed();
 			if($userExists === true) {

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -27,6 +27,7 @@ use OCA\User_SAML\UserBackend;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\IConfig;
+use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
@@ -52,6 +53,8 @@ class SAMLController extends Controller {
 	private $userManager;
 	/** @var ILogger */
 	private $logger;
+	/** @var IL10N */
+	private $l;
 
 	/**
 	 * @param string $appName
@@ -64,6 +67,7 @@ class SAMLController extends Controller {
 	 * @param IURLGenerator $urlGenerator
 	 * @param IUserManager $userManager
 	 * @param ILogger $logger
+	 * @param IL10N $l
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -74,7 +78,8 @@ class SAMLController extends Controller {
 								IConfig $config,
 								IURLGenerator $urlGenerator,
 								IUserManager $userManager,
-								ILogger $logger) {
+								ILogger $logger,
+								IL10N $l) {
 		parent::__construct($appName, $request);
 		$this->session = $session;
 		$this->userSession = $userSession;
@@ -84,6 +89,7 @@ class SAMLController extends Controller {
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
 		$this->logger = $logger;
+		$this->l = $l;
 	}
 
 	/**
@@ -287,5 +293,20 @@ class SAMLController extends Controller {
 	 */
 	public function notProvisioned() {
 		return new Http\TemplateResponse($this->appName, 'notProvisioned', [], 'guest');
+	}
+
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @OnlyUnauthenticatedUsers
+	 * @param string $message
+	 * @return Http\TemplateResponse
+	 */
+	public function genericError($message) {
+		if (empty($message)) {
+			$message = $this->l->t('Unknown error, please check the log file for more details.');
+		}
+		return new Http\TemplateResponse($this->appName, 'error', ['message' => $message], 'guest');
 	}
 }

--- a/tests/unit/AppInfo/RoutesTest.php
+++ b/tests/unit/AppInfo/RoutesTest.php
@@ -54,6 +54,11 @@ class Test extends TestCase  {
 					'url' => '/saml/notProvisioned',
 					'verb' => 'GET',
 				],
+				[
+					'name' => 'SAML#genericError',
+					'url' => '/saml/error',
+					'verb' => 'GET',
+				],
 			],
 		];
 		$this->assertSame($expected, $routes);


### PR DESCRIPTION
backport of https://github.com/nextcloud/user_saml/pull/190

detect disabled user and show a appropriated error message

Steps to test:

1. setup Nextcloud with SAML
2. Disable a saml user in the user management
3. Try to login with the disabled user

Until now: it result in a redirect loop between Nextcloud and the idp

With this PR: a appropriated error message is shown.