### PR TITLE
try to lookup a user if the uid does not resolve and autoprov is disabled

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -121,6 +121,13 @@ class SAMLController extends Controller {
 			}
 
 			if(!$userExists && !$autoProvisioningAllowed) {
+				// it is possible that the user was not logged in before and
+				// thus is not known to the original backend. A search can
+				// help with it and make the user known
+				$this->userManager->search($uid);
+				if($this->userManager->userExists($uid)) {
+					return;
+				}
 				throw new NoUserFoundException();
 			} elseif(!$userExists && $autoProvisioningAllowed) {
 				$this->userBackend->createUserIfNotExists($uid);

--- a/tests/unit/Controller/SAMLControllerTest.php
+++ b/tests/unit/Controller/SAMLControllerTest.php
@@ -367,7 +367,7 @@ class SAMLControllerTest extends TestCase  {
 			->with('user_saml', 'general-uid_mapping')
 			->willReturn('uid');
 		$this->userManager
-			->expects($this->once())
+			->expects($this->any())
 			->method('userExists')
 			->with('MyUid')
 			->willReturn(false);
@@ -382,6 +382,57 @@ class SAMLControllerTest extends TestCase  {
 			->willReturn(false);
 
 		$expected = new RedirectResponse('https://nextcloud.com/notprovisioned/');
+		$this->assertEquals($expected, $this->samlController->login());
+	}
+
+	public function testLoginWithEnvVariableAndNotYetMappedUserWithoutProvisioning() {
+		$this->config
+			->expects($this->at(0))
+			->method('getAppValue')
+			->with('user_saml', 'type')
+			->willReturn('environment-variable');
+		$this->session
+			->expects($this->once())
+			->method('get')
+			->with('user_saml.samlUserData')
+			->willReturn([
+				'foo' => 'bar',
+				'uid' => 'MyUid',
+				'bar' => 'foo',
+			]);
+		$this->config
+			->expects($this->at(1))
+			->method('getAppValue')
+			->with('user_saml', 'general-uid_mapping')
+			->willReturn('uid');
+		$this->userManager
+			->expects($this->exactly(2))
+			->method('userExists')
+			->with('MyUid')
+			->willReturnOnConsecutiveCalls(false, true);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('MyUid')
+			->willReturn($this->createMock(IUser::class));
+		$this->urlGenerator
+			->expects($this->once())
+			->method('getAbsoluteUrl')
+			->with('/')
+			->willReturn('https://nextcloud.com/absolute/');
+		$this->urlGenerator
+			->expects($this->never())
+			->method('linkToRouteAbsolute');
+		$this->userBackend
+			->expects($this->once())
+			->method('autoprovisionAllowed')
+			->willReturn(false);
+		$this->userBackend
+			->expects($this->once())
+			->method('getCurrentUserId')
+			->willReturn('MyUid');
+
+		$expected = new RedirectResponse('https://nextcloud.com/absolute/');
 		$this->assertEquals($expected, $this->samlController->login());
 	}
 


### PR DESCRIPTION
candidate to fix #162

it requires that a user can be found when a search is done against the "uid" that was returned from SAML.

Alternative would be to specify and request an attribute that should be used to discover the user. 

What do you think @schiessle?