### PR TITLE
Multiple user back ends

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -94,6 +94,10 @@ if(!$cli &&
 	!$userSession->isLoggedIn() &&
 	\OC::$server->getRequest()->getPathInfo() === '/login' &&
 	$type !== '') {
+	$params = $request->getParams();
+	if (isset($params['direct'])) {
+		return;
+	}
 	$redirectSituation = true;
 }
 
@@ -112,6 +116,26 @@ if($useSamlForDesktopClients === '1') {
 			$redirectSituation = true;
 		}
 	}
+}
+
+$multipleUserBackEnds = $config->getAppValue('user_saml', 'general-allow_multiple_user_back_ends', '0');
+
+if ($redirectSituation === true && $multipleUserBackEnds === '1') {
+	$params = $request->getParams();
+	$redirectUrl = '';
+	if(isset($params['redirect_url'])) {
+		$redirectUrl = $params['redirect_url'];
+	}
+
+	$targetUrl = $urlGenerator->linkToRouteAbsolute(
+		'user_saml.SAML.selectUserBackEnd',
+		[
+			'redirectUrl' => $redirectUrl
+		]
+	);
+	header('Location: '.$targetUrl);
+	exit();
+
 }
 
 if($redirectSituation === true) {

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -53,5 +53,10 @@ return [
 			'url' => '/saml/error',
 			'verb' => 'GET',
 		],
+		[
+			'name' => 'SAML#selectUserBackEnd',
+			'url' => '/saml/selectUserBackEnd',
+			'verb' => 'GET',
+		],
 	],
 ];

--- a/css/admin.css
+++ b/css/admin.css
@@ -5,6 +5,7 @@
 
 #user-saml input[type="checkbox"] {
 	vertical-align:middle;
+	cursor: pointer;
 }
 
 #user-saml h4 {

--- a/css/selectUserBackEnd.css
+++ b/css/selectUserBackEnd.css
@@ -1,0 +1,36 @@
+#saml-select-user-back-end {
+	color: white;
+}
+
+#saml-select-user-back-end h1 {
+	font-size: 16px;
+	padding: 20px 0;
+}
+
+.login-option {
+	background-color: #0082c9;
+	border: 1px solid #fff;
+	font-weight: 600;
+	/*padding: 13px 20px;*/
+	height: 40px;
+
+	margin: 15px 0;
+	min-width: 269px;
+	border-radius: 3px;
+	font-size: 20px;
+	color: white;
+}
+
+.login-option a {
+	display:inline-block;
+    width:100%;
+    line-height:40px;
+	color: #fff;
+	cursor: pointer;
+}
+
+.login-option .icon-confirm-white {
+	float: right;
+	line-height: 40px;
+}
+

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -373,7 +373,7 @@ class SAMLController extends Controller {
 	}
 
 	/**
-	 * get SSO URL
+	 * get Nextcloud login URL
 	 *
 	 * @return string
 	 */

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -309,4 +309,57 @@ class SAMLController extends Controller {
 		}
 		return new Http\TemplateResponse($this->appName, 'error', ['message' => $message], 'guest');
 	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @OnlyUnauthenticatedUsers
+	 * @param string $redirectUrl
+	 * @return Http\TemplateResponse
+	 */
+	public function selectUserBackEnd($redirectUrl) {
+		$loginUrls = [
+			'directLogin' => $this->getDirectLoginUrl(),
+			'ssoLogin' => $this->getSSOUrl($redirectUrl)
+		];
+		return new Http\TemplateResponse($this->appName, 'selectUserBackEnd', $loginUrls, 'guest');
+	}
+
+	/**
+	 * get SSO URL
+	 *
+	 * @param $redirectUrl
+	 * @return string
+	 */
+	private function getSSOUrl($redirectUrl) {
+
+		$originalUrl = '';
+		if(!empty($redirectUrl)) {
+			$originalUrl = $this->urlGenerator->getAbsoluteURL($redirectUrl);
+		}
+
+
+		$csrfToken = \OC::$server->getCsrfTokenManager()->getToken();
+		$ssoUrl = $this->urlGenerator->linkToRouteAbsolute(
+			'user_saml.SAML.login',
+			[
+				'requesttoken' => $csrfToken->getEncryptedValue(),
+				'originalUrl' => $originalUrl,
+			]
+		);
+
+		return $ssoUrl;
+
+	}
+
+	/**
+	 * get SSO URL
+	 *
+	 * @return string
+	 */
+	private function getDirectLoginUrl() {
+		$directUrl = $this->urlGenerator->linkToRouteAbsolute('core.login.tryLogin', ['direct' => '1']);
+		return $directUrl;
+	}
+
 }

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -319,8 +319,14 @@ class SAMLController extends Controller {
 	 */
 	public function selectUserBackEnd($redirectUrl) {
 		$loginUrls = [
-			'directLogin' => $this->getDirectLoginUrl(),
-			'ssoLogin' => $this->getSSOUrl($redirectUrl)
+			'directLogin' => [
+				'url' => $this->getDirectLoginUrl(),
+				'display-name' => $this->l->t('Direct log in')
+				],
+			'ssoLogin' => [
+				'url' => $this->getSSOUrl($redirectUrl),
+				'display-name' => $this->getSSODisplayName(),
+				]
 		];
 		return new Http\TemplateResponse($this->appName, 'selectUserBackEnd', $loginUrls, 'guest');
 	}
@@ -350,6 +356,20 @@ class SAMLController extends Controller {
 
 		return $ssoUrl;
 
+	}
+
+	/**
+	 * return the display name of the SSO identity provider
+	 *
+	 * @return string
+	 */
+	protected function getSSODisplayName() {
+		$displayName = $this->config->getAppValue('user_saml', 'general-idp0_display_name');
+		if (empty($displayName)) {
+			$displayName = $this->l->t('SSO & SAML log in');
+		}
+
+		return $displayName;
 	}
 
 	/**

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -77,6 +77,11 @@ class Admin implements ISettings {
 			'lowercaseUrlencoding' =>  $this->l10n->t('ADFS URL-Encodes SAML data as lowercase, and the toolkit by default uses uppercase. Enable for ADFS compatibility on signature verification.'),
 		];
 		$generalSettings = [
+			'idp0_display_name' => [
+				'text' => $this->l10n->t('Optional display name of the identity provider (default: "SSO & SAML log in")'),
+				'type' => 'line',
+				'required' => false,
+			],
 			'uid_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the UID to.'),
 				'type' => 'line',

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -86,6 +86,10 @@ class Admin implements ISettings {
 				'text' => $this->l10n->t('Only allow authentication if an account exists on some other backend. (e.g. LDAP)'),
 				'type' => 'checkbox',
 			],
+			'allow_multiple_user_back_ends' => [
+				'text' => $this->l10n->t('Allow the use of multiple user back-ends (e.g. LDAP)'),
+				'type' => 'checkbox',
+			],
 		];
 		$attributeMappingSettings = [
 			'displayName_mapping' => [

--- a/templates/selectUserBackEnd.php
+++ b/templates/selectUserBackEnd.php
@@ -1,0 +1,20 @@
+<?php
+style('user_saml', 'selectUserBackEnd');
+
+/** @var array $_ */
+/** @var $l \OCP\IL10N */
+?>
+
+<div id="saml-select-user-back-end">
+
+<h1>Chose login option:</h1>
+
+<div class="login-option">
+	<a href="<?php p($_['directLogin']); ?>"><?php p($l->t('Direct log in')); ?></a>
+</div>
+
+<div class="login-option">
+	<a href="<?php p($_['ssoLogin']); ?>"><?php p($l->t('SSO & SAML log in')); ?></a>
+</div>
+
+</div>

--- a/templates/selectUserBackEnd.php
+++ b/templates/selectUserBackEnd.php
@@ -10,11 +10,11 @@ style('user_saml', 'selectUserBackEnd');
 <h1>Chose login option:</h1>
 
 <div class="login-option">
-	<a href="<?php p($_['directLogin']); ?>"><?php p($l->t('Direct log in')); ?></a>
+	<a href="<?php p($_['directLogin']['url']); ?>"><?php p($_['directLogin']['display-name']); ?></a>
 </div>
 
 <div class="login-option">
-	<a href="<?php p($_['ssoLogin']); ?>"><?php p($l->t('SSO & SAML log in')); ?></a>
+	<a href="<?php p($_['ssoLogin']['url']); ?>"><?php p($_['ssoLogin']['display-name']); ?></a>
 </div>
 
 </div>

--- a/tests/unit/AppInfo/RoutesTest.php
+++ b/tests/unit/AppInfo/RoutesTest.php
@@ -59,6 +59,11 @@ class Test extends TestCase  {
 					'url' => '/saml/error',
 					'verb' => 'GET',
 				],
+				[
+					'name' => 'SAML#selectUserBackEnd',
+					'url' => '/saml/selectUserBackEnd',
+					'verb' => 'GET',
+				],
 			],
 		];
 		$this->assertSame($expected, $routes);

--- a/tests/unit/Controller/SAMLControllerTest.php
+++ b/tests/unit/Controller/SAMLControllerTest.php
@@ -407,4 +407,27 @@ class SAMLControllerTest extends TestCase  {
 			['messageSend' => 'test message', 'messageExpected' => 'test message'],
 		];
 	}
+
+	/**
+	 * @dataProvider dataTestGetSSODisplayName
+	 *
+	 * @param string $configuredDisplayName
+	 * @param string $expected
+	 */
+	public function testGetSSODisplayName($configuredDisplayName, $expected) {
+		$this->config->expects($this->any())->method('getAppValue')
+			->with('user_saml', 'general-idp0_display_name')
+			->willReturn($configuredDisplayName);
+
+		$result = $this->invokePrivate($this->samlController, 'getSSODisplayName');
+
+		$this->assertSame($expected, $result);
+	}
+
+	public function dataTestGetSSODisplayName() {
+		return [
+			['My identity provider', 'My identity provider'],
+			['', 'SSO & SAML log in']
+		];
+	}
 }

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -81,6 +81,11 @@ class AdminTest extends \Test\TestCase  {
 			'lowercaseUrlencoding' => 'ADFS URL-Encodes SAML data as lowercase, and the toolkit by default uses uppercase. Enable for ADFS compatibility on signature verification.',
 		];
 		$generalSettings = [
+			'idp0_display_name' => [
+				'text' => $this->l10n->t('Optional display name of the identity provider (default: "SSO & SAML log in")'),
+				'type' => 'line',
+				'required' => false,
+			],
 			'uid_mapping' => [
 				'text' => 'Attribute to map the UID to.',
 				'type' => 'line',

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -94,6 +94,10 @@ class AdminTest extends \Test\TestCase  {
 				'text' => 'Use SAML auth for the Nextcloud desktop clients (requires user re-authentication)',
 				'type' => 'checkbox',
 			],
+			'allow_multiple_user_back_ends' => [
+				'text' => $this->l10n->t('Allow the use of multiple user back-ends (e.g. LDAP)'),
+				'type' => 'checkbox',
+			],
 		];
 		$attributeMappingSettings = [
 			'displayName_mapping' => [


### PR DESCRIPTION
add option to enable multiple user back-ends in parallel (see second check box from the saml admin settings) and to give the identity provider a custom display name (see first input field):

![sso2](https://user-images.githubusercontent.com/1589737/37589513-d0c71848-2b65-11e8-877c-ca2c50d69442.png)


The user will then see this landing page and can decide between SSO and "direct login" which can be any user management which authenticates directly at Nextcloud (local user management, ldap,...). The SSO button has either the default name, as show here or the display name configured above.

![sso2](https://user-images.githubusercontent.com/1589737/37531080-6ba9b000-293b-11e8-9b8a-6289abb6f041.png)


@rullzer maybe you can give it a try and review it? Thanks!