### PR TITLE
Implement mapping of home directory when creating a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+
+## 2.0.1
+
+### Changed
+
+- add attribute mapping for the users home directory when creating a new user
+
+
 ## 2.0.0
 
 ### Changed

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -25,6 +25,15 @@
 				<notnull>true</notnull>
 				<length>255</length>
 			</field>
+
+			<field>
+				<name>home</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>255</length>
+			</field>
+
 		</declaration>
 	</table>
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ The following providers are supported and tested at the moment:
 	* Any other provider that authenticates using the environment variable
 
 While theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.]]></description>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>User_SAML</namespace>

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -148,7 +148,7 @@ class SAMLController extends Controller {
 				}
 				throw new NoUserFoundException('Auto provisioning not allowed and user ' . $uid . ' does not exist');
 			} elseif(!$userExists && $autoProvisioningAllowed) {
-				$this->userBackend->createUserIfNotExists($uid);
+				$this->userBackend->createUserIfNotExists($uid, $auth);
 				$this->userBackend->updateAttributes($uid, $auth);
 				return;
 			}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -120,6 +120,12 @@ class Admin implements ISettings {
 				'type' => 'line',
 				'required' => true,
 			],
+			'home_mapping' => [
+				'text' => $this->l10n->t('Attribute to map the users home to.'),
+				'type' => 'line',
+				'required' => true,
+			],
+
 		];
 
 		$type = $this->config->getAppValue('user_saml', 'type');

--- a/tests/unit/Controller/SAMLControllerTest.php
+++ b/tests/unit/Controller/SAMLControllerTest.php
@@ -340,7 +340,7 @@ class SAMLControllerTest extends TestCase  {
 			->method('createUserIfNotExists')
 			->with('MyUid');
 		$this->userBackend
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('getCurrentUserId')
 			->willReturn('MyUid');
 		$this->userManager

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -129,6 +129,11 @@ class AdminTest extends \Test\TestCase  {
 				'type' => 'line',
 				'required' => true,
 			],
+			'home_mapping' => [
+				'text' => $this->l10n->t('Attribute to map the users home to.'),
+				'type' => 'line',
+				'required' => true,
+			],
 		];
 
 		$params = [


### PR DESCRIPTION
This implements the mapping of home directories for new users.

Right now the mapping only happens when creating the user, as **changing** an existing user's home directory cannot be considered safe at the moment.

Closes #202 
Closes #206 

Signed-off-by: Daniel Klaffenbach <daniel.klaffenbach@hrz.tu-chemnitz.de>