### PR TITLE
Fixed issue where using user_saml in 'environmental variable' mode th…

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -157,7 +157,13 @@ class SAMLController extends Controller {
 				$this->session->set('user_saml.OriginalUrl', $this->request->getParam('originalUrl', ''));
 				break;
 			case 'environment-variable':
-				$ssoUrl = $this->urlGenerator->getAbsoluteURL('/');
+				$originalUrl = $this->request->getParam('originalUrl', '');
+				if($originalUrl !== null && $originalUrl !== '') {
+					$ssoUrl = $originalUrl;
+					}
+				else {
+					$ssoUrl = $this->urlGenerator->getAbsoluteURL('/');
+					};
 				$this->session->set('user_saml.samlUserData', $_SERVER);
 				try {
 					$this->autoprovisionIfPossible($this->session->get('user_saml.samlUserData'));


### PR DESCRIPTION
…e originalUrl was lost.  This would then stop "request an app password" and "grant access" features in clients from working. It would redirect them to the files page (based on /)

Signed-off-by: Jon Agland <jon@sftwales.com>

The above is complete w.r.t to user_saml.  If you need a full 'issue' then I can provide that, just hoping this was a quick/easy one.

There was a few related changes needed to my Apache webserver configuration, because the URL which the clients (on Linux) use seems to be wrong - that's my next task to workout.  The nextcloud app on Android worked fine with just the above.

```
		# NextCloud client
        	RewriteCond %{REQUEST_URI} ^/index.php$
        	RewriteCond %{QUERY_STRING} ^sectionid=security$
		RewriteRule ^/index.php /index.php/settings/user/security [R=301,L,NE,QSD]
		# ownCloud client
        	RewriteCond %{REQUEST_URI} ^/index.php/settings/personal$
        	RewriteCond %{QUERY_STRING} ^sectionid=security$
		RewriteRule ^/index.php /index.php/settings/user/security [R=301,L,NE,QSD]
```
