### PR TITLE
Allow to configure multiple providers

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -33,10 +33,12 @@ $l = \OC::$server->getL10N('user_saml');
 $config = \OC::$server->getConfig();
 $request = \OC::$server->getRequest();
 $userSession = \OC::$server->getUserSession();
+$session = \OC::$server->getSession();
 $samlSettings = new \OCA\User_SAML\SAMLSettings(
 	$urlGenerator,
 	$config,
-	$request
+	$request,
+	$session
 );
 
 $userBackend = new \OCA\User_SAML\UserBackend(
@@ -45,7 +47,8 @@ $userBackend = new \OCA\User_SAML\UserBackend(
 	\OC::$server->getSession(),
 	\OC::$server->getDatabaseConnection(),
 	\OC::$server->getUserManager(),
-	\OC::$server->getGroupManager()
+	\OC::$server->getGroupManager(),
+	$samlSettings
 );
 $userBackend->registerBackends(\OC::$server->getUserManager()->getBackends());
 OC_User::useBackend($userBackend);

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -119,9 +119,11 @@ if($useSamlForDesktopClients === '1') {
 	}
 }
 
-$multipleUserBackEnds = $config->getAppValue('user_saml', 'general-allow_multiple_user_back_ends', '0');
+$multipleUserBackEnds = $samlSettings->allowMultipleUserBackEnds();
+$configuredIdps = $samlSettings->getListOfIdps();
+$showLoginOptions = $multipleUserBackEnds || count($configuredIdps) > 1;
 
-if ($redirectSituation === true && $multipleUserBackEnds === '1') {
+if ($redirectSituation === true && $showLoginOptions) {
 	$params = $request->getParams();
 	$redirectUrl = '';
 	if(isset($params['redirect_url'])) {

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -57,7 +57,7 @@ $type = '';
 switch($config->getAppValue('user_saml', 'type')) {
 	case 'saml':
 		try {
-			$oneLoginSettings = new \OneLogin_Saml2_Settings($samlSettings->getOneLoginSettingsArray());
+			$oneLoginSettings = new \OneLogin_Saml2_Settings($samlSettings->getOneLoginSettingsArray(1));
 		} catch (OneLogin_Saml2_Error $e) {
 			$returnScript = true;
 		}

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -157,6 +157,7 @@ if($redirectSituation === true) {
 		[
 			'requesttoken' => $csrfToken->getEncryptedValue(),
 			'originalUrl' => $originalUrl,
+			'idp' => 1,
 		]
 	);
 	header('Location: '.$targetUrl);

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -58,5 +58,13 @@ return [
 			'url' => '/saml/selectUserBackEnd',
 			'verb' => 'GET',
 		],
+		[
+			'name' => 'Settings#getSamlProviderSettings',
+			'url' => '/settings/providerSettings/{providerId}',
+			'verb' => 'GET',
+			'defaults' => [
+				'providerId' => '1'
+			]
+		],
 	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -66,5 +66,13 @@ return [
 				'providerId' => '1'
 			]
 		],
+		[
+			'name' => 'Settings#deleteSamlProviderSettings',
+			'url' => '/settings/providerSettings/{providerId}',
+			'verb' => 'DELETE',
+			'defaults' => [
+				'providerId' => '1'
+			]
+		],
 	],
 ];

--- a/css/admin.css
+++ b/css/admin.css
@@ -26,6 +26,25 @@
 	clear: both;
 	padding: 7px 0;
 	cursor: pointer;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	opacity: .5;
+}
+
+#user-saml .account-list {
+	margin: 10px 0 10px 0;
+	overflow:hidden;
+	padding: 10px 0 10px 0;
+}
+#user-saml .account-list li {
+	float: left;
+}
+
+#user-saml .account-list li a:not(.button) {
+	padding: 7px;
+}
+#user-saml .account-list li a.button {
+	margin-left: 20px;
+}
+#user-saml .account-list li.active a {
+	border-bottom: 1px solid #333;
+	font-weight: bold;
 }

--- a/css/admin.css
+++ b/css/admin.css
@@ -8,6 +8,12 @@
 	cursor: pointer;
 }
 
+#user-saml h3 .icon-delete {
+	display: inline-block;
+	padding: 5px;
+	margin-bottom: -6px;
+}
+
 #user-saml h4 {
 	font-size: 14px;
 	font-weight: 300;

--- a/js/admin.js
+++ b/js/admin.js
@@ -19,8 +19,8 @@
 				if (data.ocs.data.data !== '') {
 					OCA.User_SAML.Admin.providerIds = data.ocs.data.data;
 					OCA.User_SAML.Admin.currentConfig = OCA.User_SAML.Admin.providerIds.split(',').sort()[0];
-					callback();
 				}
+				callback();
 			});
 		},
 		chooseEnv: function() {
@@ -117,7 +117,7 @@ $(function() {
 			$('[data-js="remove-idp"]').addClass('hidden');
 		}
 		// Hide depending on the setup state
-		if(type === '') {
+		if(type !== 'environment-variable' && type !== 'saml') {
 			$('#user-saml-choose-type').removeClass('hidden');
 		} else {
 			$('#user-saml-global').removeClass('hidden');

--- a/js/admin.js
+++ b/js/admin.js
@@ -186,6 +186,9 @@ $(function() {
 			});
 			$('input:checkbox[value="1"]').attr('checked', true);
 			$('input:checkbox[value="0"]').attr('checked', false);
+			var xmlDownloadButton = $('#get-metadata');
+			var url = xmlDownloadButton.data('base') + '?idp=' + providerId;
+			xmlDownloadButton.attr('href', url);
 		});
 	};
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -164,11 +164,11 @@ $(function() {
 				var entries = data[category];
 				Object.keys(entries).forEach(function (configKey) {
 					var element = $('#user-saml-settings *[data-key="' + configKey + '"]');
-					if ($('#user-saml-settings #user-saml-' + configKey).length) {
-						element = $('#user-saml-' + configKey);
+					if ($('#user-saml-settings #user-saml-' + category + ' #user-saml-' + configKey).length) {
+						element = $('#user-saml-' + category + ' #user-saml-' + configKey);
 					}
-					if ($('#user-saml-settings  [name="' + configKey + '"]').length) {
-						element = $('[name="' + configKey + '"]');
+					if ($('#user-saml-settings #user-saml-' + category + ' [name="' + configKey + '"]').length) {
+						element = $('#user-saml-' + category + ' [name="' + configKey + '"]');
 					}
 					if(element.is('input') && element.prop('type') === 'text') {
 						element.val(entries[configKey])

--- a/js/admin.js
+++ b/js/admin.js
@@ -18,7 +18,7 @@
 			this._getAppConfig('providerIds').done(function (data){
 				if (data.ocs.data.data !== '') {
 					OCA.User_SAML.Admin.providerIds = data.ocs.data.data;
-					OCA.User_SAML.Admin.currentConfig = OCA.User_SAML.Admin.providerIds.split(',')[0];
+					OCA.User_SAML.Admin.currentConfig = OCA.User_SAML.Admin.providerIds.split(',').sort()[0];
 					callback();
 				}
 			});
@@ -113,6 +113,9 @@ $(function() {
 
 	OCA.User_SAML.Admin.init(function() {
 		$('.account-list li[data-id="' + OCA.User_SAML.Admin.currentConfig + '"]').addClass('active');
+		if (OCA.User_SAML.Admin.providerIds.split(',').length <= 1) {
+			$('[data-js="remove-idp"]').addClass('hidden');
+		}
 		// Hide depending on the setup state
 		if(type === '') {
 			$('#user-saml-choose-type').removeClass('hidden');
@@ -155,7 +158,7 @@ $(function() {
 	var switchProvider = function(providerId) {
 		$('.account-list li').removeClass('active');
 		$('.account-list li[data-id="' + providerId + '"]').addClass('active');
-		OCA.User_SAML.Admin.currentConfig = providerId;
+		OCA.User_SAML.Admin.currentConfig = '' + providerId;
 		$.get(OC.generateUrl('/apps/user_saml/settings/providerSettings/' + providerId)).done(function(data) {
 			Object.keys(data).forEach(function(category, index){
 				var entries = data[category];
@@ -186,15 +189,16 @@ $(function() {
 		});
 	};
 
-	$('.account-list').on('click', 'li:not(.add-provider)', function() {
+	$('.account-list').on('click', 'li:not(.add-provider):not(.remove-provider)', function() {
 		var providerId = '' + $(this).data('id');
 		switchProvider(providerId);
 	});
 
 	$('.account-list .add-provider').on('click', function() {
 		OCA.User_SAML.Admin.addProvider(function (nextId) {
-			$('<li data-id="' + nextId + '"><a>' + t('user_saml', 'Provider') + ' ' + nextId + '</a></li>').insertBefore('.account-list .add-provider');
+			$('<li data-id="' + nextId + '"><a>' + t('user_saml', 'Provider') + ' ' + nextId + '</a></li>').insertBefore('.account-list .remove-provider');
 			switchProvider(nextId);
+			$('[data-js="remove-idp"]').removeClass('hidden');
 		});
 	});
 
@@ -202,6 +206,9 @@ $(function() {
 		OCA.User_SAML.Admin.removeProvider(function(currentConfig) {
 			$('.account-list li[data-id="' + currentConfig + '"]').remove();
 			switchProvider(OCA.User_SAML.Admin.providerIds.split(',')[0]);
+			if (OCA.User_SAML.Admin.providerIds.split(',').length <= 1) {
+				$('[data-js="remove-idp"]').addClass('hidden');
+			}
 		});
 	});
 

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -337,7 +337,7 @@ class SAMLController extends Controller {
 
 		$loginUrls = [];
 
-		if ($this->settings->allowMultipleUserBackEnds()) {
+		if ($this->SAMLSettings->allowMultipleUserBackEnds()) {
 			$loginUrls['directLogin'] = [
 				'url' => $this->getDirectLoginUrl(),
 				'display-name' => $this->l->t('Direct log in')
@@ -357,7 +357,7 @@ class SAMLController extends Controller {
 	 */
 	private function getIdps($redirectUrl) {
 		$result = [];
-		$idps = $this->settings->getListOfIdps();
+		$idps = $this->SAMLSettings->getListOfIdps();
 		foreach ($idps as $idpId => $displayName) {
 			$result[] = [
 				'url' => $this->getSSOUrl($redirectUrl, $idpId),

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -67,7 +67,6 @@ class SAMLController extends Controller {
 	 * @param IURLGenerator $urlGenerator
 	 * @param IUserManager $userManager
 	 * @param ILogger $logger
-	 * @param SAMLSettings $settings
 	 * @param IL10N $l
 	 */
 	public function __construct($appName,

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -55,8 +55,6 @@ class SAMLController extends Controller {
 	private $logger;
 	/** @var IL10N */
 	private $l;
-	/** @var SAMLSettings */
-	private $settings;
 
 	/**
 	 * @param string $appName
@@ -82,7 +80,6 @@ class SAMLController extends Controller {
 								IURLGenerator $urlGenerator,
 								IUserManager $userManager,
 								ILogger $logger,
-								SAMLSettings $settings,
 								IL10N $l) {
 		parent::__construct($appName, $request);
 		$this->session = $session;
@@ -93,7 +90,6 @@ class SAMLController extends Controller {
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
 		$this->logger = $logger;
-		$this->settings = $settings;
 		$this->l = $l;
 	}
 
@@ -102,7 +98,7 @@ class SAMLController extends Controller {
 	 * @throws NoUserFoundException
 	 */
 	private function autoprovisionIfPossible(array $auth) {
-		$prefix = $this->settings->getPrefix();
+		$prefix = $this->SAMLSettings->getPrefix();
 		$uidMapping = $this->config->getAppValue('user_saml', $prefix . 'general-uid_mapping');
 		if(isset($auth[$uidMapping])) {
 			if(is_array($auth[$uidMapping])) {

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -102,7 +102,8 @@ class SAMLController extends Controller {
 	 * @throws NoUserFoundException
 	 */
 	private function autoprovisionIfPossible(array $auth) {
-		$uidMapping = $this->config->getAppValue('user_saml', 'general-uid_mapping');
+		$prefix = $this->settings->getPrefix();
+		$uidMapping = $this->config->getAppValue('user_saml', $prefix . 'general-uid_mapping');
 		if(isset($auth[$uidMapping])) {
 			if(is_array($auth[$uidMapping])) {
 				$uid = $auth[$uidMapping][0];

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -149,14 +149,15 @@ class SAMLController extends Controller {
 	 * @UseSession
 	 * @OnlyUnauthenticatedUsers
 	 *
+	 * @param int $idp id of the idp
 	 * @return Http\RedirectResponse
 	 * @throws \Exception
 	 */
-	public function login() {
+	public function login($idp) {
 		$type = $this->config->getAppValue($this->appName, 'type');
 		switch($type) {
 			case 'saml':
-				$auth = new \OneLogin_Saml2_Auth($this->SAMLSettings->getOneLoginSettingsArray());
+				$auth = new \OneLogin_Saml2_Auth($this->SAMLSettings->getOneLoginSettingsArray($idp));
 				$ssoUrl = $auth->login(null, [], false, false, true);
 				$this->session->set('user_saml.AuthNRequestID', $auth->getLastRequestID());
 				$this->session->set('user_saml.OriginalUrl', $this->request->getParam('originalUrl', ''));

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Controller;
+
+use OCA\User_SAML\Settings\Admin;
+use OCP\AppFramework\Controller;
+use OCP\IConfig;
+use OCP\IRequest;
+
+class SettingsController extends Controller {
+
+	/** @var IConfig */
+	private $config;
+	/** @var Admin */
+	private $admin;
+
+	public function __construct($appName,
+								IRequest $request,
+								IConfig $config,
+								Admin $admin) {
+		parent::__construct($appName, $request);
+		$this->config = $config;
+		$this->admin = $admin;
+	}
+
+	/**
+	 * @param $providerId
+	 * @return array of categories containing entries for each config parameter with their value
+	 */
+	public function getSamlProviderSettings($providerId) {
+		/**
+		 * This uses the list of available config parameters from the admin section
+		 * and extends it with fields that are not coming from \OCA\User_SAML\Settings\Admin
+		 */
+		$params = $this->admin->getForm()->getParams();
+		$params['idp'] = [
+			'singleLogoutService.url' => null,
+			'singleSignOnService.url' => null,
+			'idp-entityId' => null,
+		];
+		/* Fetch all config values for the given providerId */
+		$settings = [];
+		foreach ($params as $category => $content) {
+			if (empty($content) || $category === 'providers') {
+				continue;
+			}
+			foreach ($content as $setting => $details) {
+				$prefix = $providerId === '1' ? '' : $providerId . '-';
+				$key = $prefix . $category . '-' . $setting;
+				/* use security as category instead of security-* */
+				if (strpos($category, 'security-') === 0) {
+					$category = 'security';
+				}
+				$settings[$category][$setting] = $this->config->getAppValue('user_saml', $key, '');
+			}
+		}
+		return $settings;
+	}
+
+}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -25,6 +25,7 @@ namespace OCA\User_SAML\Controller;
 
 use OCA\User_SAML\Settings\Admin;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Response;
 use OCP\IConfig;
 use OCP\IRequest;
 
@@ -103,6 +104,7 @@ class SettingsController extends Controller {
 				$this->config->deleteAppValue('user_saml', $key);
 			}
 		}
+		return new Response();
 	}
 
 }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -64,7 +64,7 @@ class SettingsController extends Controller {
 		/* Fetch all config values for the given providerId */
 		$settings = [];
 		foreach ($params as $category => $content) {
-			if (empty($content) || $category === 'providers') {
+			if (empty($content) || $category === 'providers' || $category === 'type') {
 				continue;
 			}
 			foreach ($content as $setting => $details) {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -56,9 +56,10 @@ class SettingsController extends Controller {
 		 */
 		$params = $this->admin->getForm()->getParams();
 		$params['idp'] = [
-			'singleLogoutService.url' => null,
-			'singleSignOnService.url' => null,
-			'idp-entityId' => null,
+			'singleLogoutService.url' => ['required' => false],
+			'singleSignOnService.url' => ['required' => false],
+			'entityId' => ['required' => false],
+			'x509cert' => ['required' => false],
 		];
 		/* Fetch all config values for the given providerId */
 		$settings = [];
@@ -68,11 +69,11 @@ class SettingsController extends Controller {
 			}
 			foreach ($content as $setting => $details) {
 				$prefix = $providerId === '1' ? '' : $providerId . '-';
-				$key = $prefix . $category . '-' . $setting;
 				/* use security as category instead of security-* */
 				if (strpos($category, 'security-') === 0) {
 					$category = 'security';
 				}
+				$key = $prefix . $category . '-' . $setting;
 				$settings[$category][$setting] = $this->config->getAppValue('user_saml', $key, '');
 			}
 		}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -73,7 +73,14 @@ class SettingsController extends Controller {
 				if (strpos($category, 'security-') === 0) {
 					$category = 'security';
 				}
-				$key = $prefix . $category . '-' . $setting;
+				// make sure we properly fetch the attribute mapping
+				// as this is the only category that has the saml- prefix on config keys
+				if (strpos($category, 'attribute-mapping') === 0) {
+					$category = 'attribute-mapping';
+					$key = $prefix . 'saml-attribute-mapping' . '-' . $setting;
+				} else {
+					$key = $prefix . $category . '-' . $setting;
+				}
 				$settings[$category][$setting] = $this->config->getAppValue('user_saml', $key, '');
 			}
 		}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -78,4 +78,31 @@ class SettingsController extends Controller {
 		return $settings;
 	}
 
+	public function deleteSamlProviderSettings($providerId) {
+		$params = $this->admin->getForm()->getParams();
+		$params['idp'] = [
+			'singleLogoutService.url' => null,
+			'singleSignOnService.url' => null,
+			'idp-entityId' => null,
+		];
+		/* Fetch all config values for the given providerId */
+		foreach ($params as $category => $content) {
+			if (empty($content) || $category === 'providers') {
+				continue;
+			}
+			foreach ($content as $setting => $details) {
+				if ($details['global']) {
+					continue;
+				}
+				$prefix = $providerId === '1' ? '' : $providerId . '-';
+				$key = $prefix . $category . '-' . $setting;
+				/* use security as category instead of security-* */
+				if (strpos($category, 'security-') === 0) {
+					$category = 'security';
+				}
+				$this->config->deleteAppValue('user_saml', $key);
+			}
+		}
+	}
+
 }

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -47,7 +47,37 @@ class SAMLSettings {
 		$this->request = $request;
 	}
 
+	/**
+	 * get list of the configured IDPs
+	 *
+	 * @return array
+	 */
+	public function getListOfIdps() {
+		$result = [];
+
+		$providerIds = explode(',', $this->config->getAppValue('user_saml', 'providerIds', '1'));
+		natsort($providerIds);
+
+		foreach ($providerIds as $id) {
+			$prefix = $id === '1' ? '' : $id .'-';
+			$result[$id] = $this->config->getAppValue('user_saml', $prefix . 'general-idp0_display_name', '');
+		}
+
+		return $result;
+	}
+
+	/**
+	 * check if multiple user back ends are allowed
+	 *
+	 * @return bool
+	 */
+	public function allowMultipleUserBackEnds() {
+		$setting = $this->config->getAppValue('user_saml', 'general-allow_multiple_user_back_ends', '0');
+		return  $setting === '1';
+	}
+
 	public function getOneLoginSettingsArray() {
+
 		$settings = [
 			'strict' => true,
 			'debug' => $this->config->getSystemValue('debug', false),

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -76,26 +76,37 @@ class SAMLSettings {
 		return  $setting === '1';
 	}
 
-	public function getOneLoginSettingsArray() {
+	/**
+	 * get config for given IDP
+	 *
+	 * @param int $idp
+	 * @return array
+	 */
+	public function getOneLoginSettingsArray($idp) {
+
+		$prefix = '';
+		if ($idp > 1) {
+			$prefix = $idp . '-';
+		}
 
 		$settings = [
 			'strict' => true,
 			'debug' => $this->config->getSystemValue('debug', false),
 			'baseurl' => $this->request->getServerProtocol() . '://' . $this->request->getServerHost(),
 			'security' => [
-				'nameIdEncrypted' => ($this->config->getAppValue('user_saml', 'security-nameIdEncrypted', '0') === '1') ? true : false,
-				'authnRequestsSigned' => ($this->config->getAppValue('user_saml', 'security-authnRequestsSigned', '0') === '1') ? true : false,
-				'logoutRequestSigned' => ($this->config->getAppValue('user_saml', 'security-logoutRequestSigned', '0') === '1') ? true : false,
-				'logoutResponseSigned' => ($this->config->getAppValue('user_saml', 'security-logoutResponseSigned', '0') === '1') ? true : false,
-				'signMetadata' => ($this->config->getAppValue('user_saml', 'security-signMetadata', '0') === '1') ? true : false,
-				'wantMessagesSigned' => ($this->config->getAppValue('user_saml', 'security-wantMessagesSigned', '0') === '1') ? true : false,
-				'wantAssertionsSigned' => ($this->config->getAppValue('user_saml', 'security-wantAssertionsSigned', '0') === '1') ? true : false,
-				'wantAssertionsEncrypted' => ($this->config->getAppValue('user_saml', 'security-wantAssertionsEncrypted', '0') === '1') ? true : false,
-				'wantNameId' => ($this->config->getAppValue('user_saml', 'security-wantNameId', '0') === '1') ? true : false,
-				'wantNameIdEncrypted' => ($this->config->getAppValue('user_saml', 'security-wantNameIdEncrypted', '0') === '1') ? true : false,
-				'wantXMLValidation' => ($this->config->getAppValue('user_saml', 'security-wantXMLValidation', '0') === '1') ? true : false,
+				'nameIdEncrypted' => ($this->config->getAppValue('user_saml', $prefix . 'security-nameIdEncrypted', '0') === '1') ? true : false,
+				'authnRequestsSigned' => ($this->config->getAppValue('user_saml', $prefix . 'security-authnRequestsSigned', '0') === '1') ? true : false,
+				'logoutRequestSigned' => ($this->config->getAppValue('user_saml', $prefix . 'security-logoutRequestSigned', '0') === '1') ? true : false,
+				'logoutResponseSigned' => ($this->config->getAppValue('user_saml', $prefix . 'security-logoutResponseSigned', '0') === '1') ? true : false,
+				'signMetadata' => ($this->config->getAppValue('user_saml', $prefix . 'security-signMetadata', '0') === '1') ? true : false,
+				'wantMessagesSigned' => ($this->config->getAppValue('user_saml', $prefix . 'security-wantMessagesSigned', '0') === '1') ? true : false,
+				'wantAssertionsSigned' => ($this->config->getAppValue('user_saml', $prefix . 'security-wantAssertionsSigned', '0') === '1') ? true : false,
+				'wantAssertionsEncrypted' => ($this->config->getAppValue('user_saml', $prefix . 'security-wantAssertionsEncrypted', '0') === '1') ? true : false,
+				'wantNameId' => ($this->config->getAppValue('user_saml', $prefix . 'security-wantNameId', '0') === '1') ? true : false,
+				'wantNameIdEncrypted' => ($this->config->getAppValue('user_saml', $prefix . 'security-wantNameIdEncrypted', '0') === '1') ? true : false,
+				'wantXMLValidation' => ($this->config->getAppValue('user_saml', $prefix . 'security-wantXMLValidation', '0') === '1') ? true : false,
 				'requestedAuthnContext' => false,
-				'lowercaseUrlencoding' => ($this->config->getAppValue('user_saml', 'security-lowercaseUrlencoding', '0') === '1') ? true : false,
+				'lowercaseUrlencoding' => ($this->config->getAppValue('user_saml', $prefix . 'security-lowercaseUrlencoding', '0') === '1') ? true : false,
 			],
 			'sp' => [
 				'entityId' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.getMetadata'),
@@ -104,15 +115,15 @@ class SAMLSettings {
 				],
 			],
 			'idp' => [
-				'entityId' => $this->config->getAppValue('user_saml', 'idp-entityId', ''),
+				'entityId' => $this->config->getAppValue('user_saml', $prefix . 'idp-entityId', ''),
 				'singleSignOnService' => [
-					'url' => $this->config->getAppValue('user_saml', 'idp-singleSignOnService.url', ''),
+					'url' => $this->config->getAppValue('user_saml', $prefix . 'idp-singleSignOnService.url', ''),
 				],
 			],
 		];
 
-		$spx509cert = $this->config->getAppValue('user_saml', 'sp-x509cert', '');
-		$spxprivateKey = $this->config->getAppValue('user_saml', 'sp-privateKey', '');
+		$spx509cert = $this->config->getAppValue('user_saml', $prefix . 'sp-x509cert', '');
+		$spxprivateKey = $this->config->getAppValue('user_saml', $prefix . 'sp-privateKey', '');
 		if($spx509cert !== '') {
 			$settings['sp']['x509cert'] = $spx509cert;
 		}
@@ -120,15 +131,15 @@ class SAMLSettings {
 			$settings['sp']['privateKey'] = $spxprivateKey;
 		}
 
-		$idpx509cert = $this->config->getAppValue('user_saml', 'idp-x509cert', '');
+		$idpx509cert = $this->config->getAppValue('user_saml', $prefix . 'idp-x509cert', '');
 		if($idpx509cert !== '') {
 			$settings['idp']['x509cert'] = $idpx509cert;
 		}
 
-		$slo = $this->config->getAppValue('user_saml', 'idp-singleLogoutService.url', '');
+		$slo = $this->config->getAppValue('user_saml', $prefix . 'idp-singleLogoutService.url', '');
 		if($slo !== '') {
 			$settings['idp']['singleLogoutService'] = [
-				'url' => $this->config->getAppValue('user_saml', 'idp-singleLogoutService.url', ''),
+				'url' => $this->config->getAppValue('user_saml', $prefix . 'idp-singleLogoutService.url', ''),
 			];
 			$settings['sp']['singleLogoutService'] = [
 				'url' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.singleLogoutService'),

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -24,6 +24,7 @@ namespace OCA\User_SAML;
 use OCP\AppFramework\Http;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\ISession;
 use OCP\IURLGenerator;
 
 class SAMLSettings {
@@ -33,18 +34,25 @@ class SAMLSettings {
 	private $config;
 	/** @var IRequest */
 	private $request;
+	/** @var ISession */
+	private $session;
+	/** @var array list of global settings which are valid for every idp */
+	private $globalSettings = ['general-require_provisioned_account', 'general-allow_multiple_user_back_ends', 'general-use_saml_auth_for_desktop'];
 
 	/**
 	 * @param IURLGenerator $urlGenerator
 	 * @param IConfig $config
 	 * @param IRequest $request
+	 * @param ISession $session
 	 */
 	public function __construct(IURLGenerator $urlGenerator,
 								IConfig $config,
-								IRequest $request) {
+								IRequest $request,
+								ISession $session) {
 		$this->urlGenerator = $urlGenerator;
 		$this->config = $config;
 		$this->request = $request;
+		$this->session = $session;
 	}
 
 	/**
@@ -148,5 +156,26 @@ class SAMLSettings {
 
 		return $settings;
 	}
-}
 
+	/**
+	 * calculate prefix for config values
+	 *
+	 * @param string name of the setting
+	 * @return string
+	 */
+	public function getPrefix($setting = '') {
+
+		$prefix = '';
+		if (!empty($setting) && in_array($setting, $this->globalSettings)) {
+			return $prefix;
+		}
+
+		$idp = $this->session->get('user_saml.Idp');
+		if ((int)$idp > 1) {
+			$prefix = $idp . '-';
+		}
+
+		return $prefix;
+	}
+
+}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -54,6 +54,13 @@ class Admin implements ISettings {
 	 * @return TemplateResponse
 	 */
 	public function getForm() {
+		$providerIds = explode(',', $this->config->getAppValue('user_saml', 'providerIds', '1'));
+		$providers = [];
+		foreach ($providerIds as $id) {
+			$prefix = $id === '1' ? '' : $id .'-';
+			$name = $this->config->getAppValue('user_saml', $prefix . 'general-idp0_display_name', '');
+			$providers[$id] = $name === '' ? $this->l10n->t('Provider ') . $id : $name;
+		}
 		$serviceProviderFields = [
 			'x509cert' => $this->l10n->t('X.509 certificate of the Service Provider'),
 			'privateKey' => $this->l10n->t('Private key of the Service Provider'),
@@ -135,6 +142,7 @@ class Admin implements ISettings {
 			'general' => $generalSettings,
 			'attributeMappings' => $attributeMappingSettings,
 			'type' => $type,
+			'providers' => $providers
 		];
 
 		return new TemplateResponse('user_saml', 'admin', $params);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -55,11 +55,15 @@ class Admin implements ISettings {
 	 */
 	public function getForm() {
 		$providerIds = explode(',', $this->config->getAppValue('user_saml', 'providerIds', '1'));
+		natsort($providerIds);
 		$providers = [];
 		foreach ($providerIds as $id) {
 			$prefix = $id === '1' ? '' : $id .'-';
 			$name = $this->config->getAppValue('user_saml', $prefix . 'general-idp0_display_name', '');
-			$providers[$id] = $name === '' ? $this->l10n->t('Provider ') . $id : $name;
+			$providers[] = [
+				'id' => $id,
+				'name' => $name === '' ? $this->l10n->t('Provider ') . $id : $name
+				];
 		}
 		$serviceProviderFields = [
 			'x509cert' => $this->l10n->t('X.509 certificate of the Service Provider'),

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -148,7 +148,7 @@ class Admin implements ISettings {
 			'security-required' => $securityRequiredFields,
 			'security-general' => $securityGeneral,
 			'general' => $generalSettings,
-			'attributeMappings' => $attributeMappingSettings,
+			'attribute-mapping' => $attributeMappingSettings,
 			'type' => $type,
 			'providers' => $providers
 		];

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -97,10 +97,13 @@ class Admin implements ISettings {
 			'require_provisioned_account' => [
 				'text' => $this->l10n->t('Only allow authentication if an account exists on some other backend. (e.g. LDAP)'),
 				'type' => 'checkbox',
+				'global' => true,
 			],
 			'allow_multiple_user_back_ends' => [
 				'text' => $this->l10n->t('Allow the use of multiple user back-ends (e.g. LDAP)'),
 				'type' => 'checkbox',
+				'hideForEnv' => true,
+				'global' => true,
 			],
 		];
 		$attributeMappingSettings = [
@@ -131,6 +134,7 @@ class Admin implements ISettings {
 			$generalSettings['use_saml_auth_for_desktop'] = [
 				'text' => $this->l10n->t('Use SAML auth for the %s desktop clients (requires user re-authentication)', [$this->defaults->getName()]),
 				'type' => 'checkbox',
+				'global' => true,
 			];
 		}
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -10,6 +10,29 @@ style('user_saml', 'admin');
 	   title="<?php p($l->t('Open documentation'));?>"
 	   href="<?php p(link_to_docs('admin-sso')); ?>"></a>
 
+
+	<div class="warning hidden" id="user-saml-warning-admin-user">
+		<?php p(
+			$l->t(
+				'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore, unless you enabled "%s"',
+				[
+					$theme->getEntity(),
+					$_['general']['allow_multiple_user_back_ends']['text']
+				]
+			)
+		)
+		?>
+	</div>
+
+	<ul class="account-list">
+		<?php foreach ($_['providers'] as $id => $name) { ?>
+		<li data-id="<?php p($id); ?>" class="<?php if ((string)$id === '1') { p('active'); } ?>">
+			<a href="#"><?php p($name); ?></a>
+		</li>
+		<?php } ?>
+		<li class="add-provider"><a href="#" class="button"><span class="icon-add"></span> Add another account</a></li>
+	</ul>
+
 	<div id="user-saml-save-indicator" class="msg success inlineblock" style="display: none;">Saved</div>
 
 	<div id="user-saml-settings">
@@ -20,18 +43,6 @@ style('user_saml', 'admin');
 			<button id="user-saml-choose-env"><?php p($l->t('Use environment variable')) ?></button>
 		</div>
 
-		<div class="warning hidden" id="user-saml-warning-admin-user">
-			<?php p(
-				$l->t(
-					'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore, unless you enabled "%s"',
-					[
-						$theme->getEntity(),
-						$_['general']['allow_multiple_user_back_ends']['text']
-					]
-				)
-			)
-			?>
-		</div>
 
 		<div id="user-saml-general">
 			<h3><?php p($l->t('General')) ?></h3>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -30,10 +30,10 @@ style('user_saml', 'admin');
 			<a href="#"><?php p($name); ?></a>
 		</li>
 		<?php } ?>
-		<li class="add-provider"><a href="#" class="button"><span class="icon-add"></span> Add another account</a></li>
+		<li class="add-provider"><a href="#" class="button"><span class="icon-add"></span> <?php p($l->t('Add another provider')); ?></a></li>
 	</ul>
 
-	<div id="user-saml-save-indicator" class="msg success inlineblock" style="display: none;">Saved</div>
+	<div id="user-saml-save-indicator" class="msg success inlineblock" style="display: none;"><?php p($l->t('Saved')); ?></div>
 
 	<div id="user-saml-settings">
 		<div id="user-saml-choose-type">

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -49,12 +49,12 @@ style('user_saml', 'admin');
 			<?php foreach($_['general'] as $key => $attribute): ?>
 				<?php if($attribute['type'] === 'checkbox'): ?>
 					<p>
-						<input type="checkbox" id="user-saml-general-<?php p($key)?>" name="<?php p($key)?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '0')) ?>">
+						<input type="checkbox" data-key="<?php p($key)?>" id="user-saml-general-<?php p($key)?>" name="<?php p($key)?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '0')) ?>">
 						<label for="user-saml-general-<?php p($key)?>"><?php p($attribute['text']) ?></label><br/>
 					</p>
 				<?php elseif($attribute['type'] === 'line'): ?>
 					<p>
-						<input name="<?php p($key) ?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '')) ?>" type="text" <?php if(isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
+						<input data-key="<?php p($key)?>" name="<?php p($key) ?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '')) ?>" type="text" <?php if(isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
 					</p>
 				<?php endif; ?>
 			<?php endforeach; ?>
@@ -83,7 +83,7 @@ style('user_saml', 'admin');
 				<?php print_unescaped($l->t('Configure your IdP settings here.')) ?>
 							</p>
 
-			<p><input name="entityId" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-entityId', '')) ?>" type="text" class="required" placeholder="<?php p($l->t('Identifier of the IdP entity (must be a URI)')) ?>"/></p>
+			<p><input data-key="idp-entityId" name="entityId" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-entityId', '')) ?>" type="text" class="required" placeholder="<?php p($l->t('Identifier of the IdP entity (must be a URI)')) ?>"/></p>
 			<p><input name="singleSignOnService.url" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'idp-singleSignOnService.url', '')) ?>"  type="text" class="required" placeholder="<?php p($l->t('URL Target of the IdP where the SP will send the Authentication Request Message')) ?>"/></p>
 			<p><span class="toggle"><?php p($l->t('Show optional Identity Provider settings…')) ?></span></p>
 			<div class="hidden">

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -162,7 +162,10 @@ style('user_saml', 'admin');
 			</div>
 		</div>
 
-		<a href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('user_saml.SAML.getMetadata')) ?>" class="button"><?php p($l->t('Download metadata XML')) ?></a>
+		<a id="get-metadata" data-base="<?php p(\OC::$server->getURLGenerator()->linkToRoute('user_saml.SAML.getMetadata')); ?>"
+		   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('user_saml.SAML.getMetadata', ['idp' => $_['providers'][0]['id']])) ?>" class="button">
+			<?php p($l->t('Download metadata XML')) ?>
+		</a>
 		<span class="warning hidden" id="user-saml-settings-incomplete"><?php p($l->t('Metadata invalid')) ?></span>
 		<span class="success hidden" id="user-saml-settings-complete"><?php p($l->t('Metadata valid')) ?></span>
 	</div>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -51,12 +51,12 @@ style('user_saml', 'admin');
 	</div>
 
 	<ul class="account-list hidden">
-		<?php foreach ($_['providers'] as $id => $name) { ?>
-		<li data-id="<?php p($id); ?>">
-			<a href="#"><?php p($name); ?></a>
+		<?php foreach ($_['providers'] as $provider) { ?>
+		<li data-id="<?php p($provider['id']); ?>">
+			<a href="#"><?php p($provider['name']); ?></a>
 		</li>
 		<?php } ?>
-		<li><a data-js="remove-idp" class="icon-delete"><span class="hidden-visually"><?php p($l->t('Remove identity provider')); ?></span></a></li>
+		<li class="remove-provider"><a data-js="remove-idp" class="icon-delete"><span class="hidden-visually"><?php p($l->t('Remove identity provider')); ?></span></a></li>
 		<li class="add-provider"><a href="#" class="button"><span class="icon-add"></span> <?php p($l->t('Add identity provider')); ?></a></li>
 	</ul>
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -120,7 +120,7 @@ style('user_saml', 'admin');
 			</p>
 
 			<div class="hidden">
-				<?php foreach($_['attributeMappings'] as $key => $attribute): ?>
+				<?php foreach($_['attribute-mapping'] as $key => $attribute): ?>
 					<?php
 					if($attribute['type'] === 'line'): ?>
 					<p>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -24,35 +24,51 @@ style('user_saml', 'admin');
 		?>
 	</div>
 
-	<ul class="account-list">
+	<div id="user-saml-choose-type" class="hidden">
+		<?php p($l->t('Please choose whether you want to authenticate using the SAML provider built-in in Nextcloud or whether you want to authenticate against an environment variable.')) ?>
+		<br/>
+		<button id="user-saml-choose-saml"><?php p($l->t('Use built-in SAML authentication')) ?></button>
+		<button id="user-saml-choose-env"><?php p($l->t('Use environment variable')) ?></button>
+	</div>
+
+	<div id="user-saml-save-indicator" class="msg success inlineblock" style="display: none;"><?php p($l->t('Saved')); ?></div>
+
+	<div id="user-saml-global" class="hidden">
+		<h3><?php p($l->t('Global settings')) ?></h3>
+		<?php foreach($_['general'] as $key => $attribute): ?>
+			<?php if($attribute['type'] === 'checkbox' && $attribute['global']): ?>
+				<p>
+					<input type="checkbox" data-key="<?php p($key)?>" id="user-saml-general-<?php p($key)?>" name="<?php p($key)?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '0')) ?>">
+					<label for="user-saml-general-<?php p($key)?>"><?php p($attribute['text']) ?></label><br/>
+				</p>
+			<?php elseif($attribute['type'] === 'line' && $attribute['global']): ?>
+				<p>
+					<input data-key="<?php p($key)?>" name="<?php p($key) ?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '')) ?>" type="text" <?php if(isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
+				</p>
+			<?php endif; ?>
+		<?php endforeach; ?>
+	</div>
+
+	<ul class="account-list hidden">
 		<?php foreach ($_['providers'] as $id => $name) { ?>
 		<li data-id="<?php p($id); ?>" class="<?php if ((string)$id === '1') { p('active'); } ?>">
 			<a href="#"><?php p($name); ?></a>
 		</li>
 		<?php } ?>
-		<li class="add-provider"><a href="#" class="button"><span class="icon-add"></span> <?php p($l->t('Add another provider')); ?></a></li>
+		<li class="add-provider"><a href="#" class="button"><span class="icon-add"></span> <?php p($l->t('Add identity provider')); ?></a></li>
 	</ul>
 
-	<div id="user-saml-save-indicator" class="msg success inlineblock" style="display: none;"><?php p($l->t('Saved')); ?></div>
+	<div id="user-saml-settings" class="hidden">
 
-	<div id="user-saml-settings">
-		<div id="user-saml-choose-type">
-			<?php p($l->t('Please choose whether you want to authenticate using the SAML provider built-in in Nextcloud or whether you want to authenticate against an environment variable.')) ?>
-			<br/>
-			<button id="user-saml-choose-saml"><?php p($l->t('Use built-in SAML authentication')) ?></button>
-			<button id="user-saml-choose-env"><?php p($l->t('Use environment variable')) ?></button>
-		</div>
-
-
-		<div id="user-saml-general">
+		<div id="user-saml-general" class="hidden">
 			<h3><?php p($l->t('General')) ?></h3>
 			<?php foreach($_['general'] as $key => $attribute): ?>
-				<?php if($attribute['type'] === 'checkbox'): ?>
+				<?php if($attribute['type'] === 'checkbox' && !$attribute['global']): ?>
 					<p>
 						<input type="checkbox" data-key="<?php p($key)?>" id="user-saml-general-<?php p($key)?>" name="<?php p($key)?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '0')) ?>">
 						<label for="user-saml-general-<?php p($key)?>"><?php p($attribute['text']) ?></label><br/>
 					</p>
-				<?php elseif($attribute['type'] === 'line'): ?>
+				<?php elseif($attribute['type'] === 'line' && !$attribute['global']): ?>
 					<p>
 						<input data-key="<?php p($key)?>" name="<?php p($key) ?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '')) ?>" type="text" <?php if(isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
 					</p>
@@ -142,6 +158,7 @@ style('user_saml', 'admin');
 			</div>
 		</div>
 
+		<a data-js="remove-idp" class="button"><?php p($l->t('Remove identity provider')); ?></button>
 		<a href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('user_saml.SAML.getMetadata')) ?>" class="button"><?php p($l->t('Download metadata XML')) ?></a>
 		<span class="warning hidden" id="user-saml-settings-incomplete"><?php p($l->t('Metadata invalid')) ?></span>
 		<span class="success hidden" id="user-saml-settings-complete"><?php p($l->t('Metadata valid')) ?></span>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -10,6 +10,9 @@ style('user_saml', 'admin');
 	   title="<?php p($l->t('Open documentation'));?>"
 	   href="<?php p(link_to_docs('admin-sso')); ?>"></a>
 
+	<div id="user-saml-save-indicator" class="msg success inlineblock" style="display: none;"><?php p($l->t('Saved')); ?></div>
+
+
 
 	<div class="warning hidden" id="user-saml-warning-admin-user">
 		<?php p(
@@ -31,8 +34,6 @@ style('user_saml', 'admin');
 		<button id="user-saml-choose-env"><?php p($l->t('Use environment variable')) ?></button>
 	</div>
 
-	<div id="user-saml-save-indicator" class="msg success inlineblock" style="display: none;"><?php p($l->t('Saved')); ?></div>
-
 	<div id="user-saml-global" class="hidden">
 		<h3><?php p($l->t('Global settings')) ?></h3>
 		<?php foreach($_['general'] as $key => $attribute): ?>
@@ -51,17 +52,20 @@ style('user_saml', 'admin');
 
 	<ul class="account-list hidden">
 		<?php foreach ($_['providers'] as $id => $name) { ?>
-		<li data-id="<?php p($id); ?>" class="<?php if ((string)$id === '1') { p('active'); } ?>">
+		<li data-id="<?php p($id); ?>">
 			<a href="#"><?php p($name); ?></a>
 		</li>
 		<?php } ?>
+		<li><a data-js="remove-idp" class="icon-delete"><span class="hidden-visually"><?php p($l->t('Remove identity provider')); ?></span></a></li>
 		<li class="add-provider"><a href="#" class="button"><span class="icon-add"></span> <?php p($l->t('Add identity provider')); ?></a></li>
 	</ul>
 
 	<div id="user-saml-settings" class="hidden">
 
 		<div id="user-saml-general" class="hidden">
-			<h3><?php p($l->t('General')) ?></h3>
+			<h3>
+				<?php p($l->t('General')) ?>
+			</h3>
 			<?php foreach($_['general'] as $key => $attribute): ?>
 				<?php if($attribute['type'] === 'checkbox' && !$attribute['global']): ?>
 					<p>
@@ -158,7 +162,6 @@ style('user_saml', 'admin');
 			</div>
 		</div>
 
-		<a data-js="remove-idp" class="button"><?php p($l->t('Remove identity provider')); ?></button>
 		<a href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('user_saml.SAML.getMetadata')) ?>" class="button"><?php p($l->t('Download metadata XML')) ?></a>
 		<span class="warning hidden" id="user-saml-settings-incomplete"><?php p($l->t('Metadata invalid')) ?></span>
 		<span class="success hidden" id="user-saml-settings-complete"><?php p($l->t('Metadata valid')) ?></span>

--- a/templates/selectUserBackEnd.php
+++ b/templates/selectUserBackEnd.php
@@ -9,12 +9,16 @@ style('user_saml', 'selectUserBackEnd');
 
 <h1>Choose login option:</h1>
 
+	<?php if(isset($_['directLogin'])) : ?>
 <div class="login-option">
 	<a href="<?php p($_['directLogin']['url']); ?>"><?php p($_['directLogin']['display-name']); ?></a>
 </div>
+	<?php endif; ?>
 
+	<?php foreach ($_['ssoLogin'] as $idp) { ?>
 <div class="login-option">
-	<a href="<?php p($_['ssoLogin']['url']); ?>"><?php p($_['ssoLogin']['display-name']); ?></a>
+	<a href="<?php p($idp['url']); ?>"><?php p($idp['display-name']); ?></a>
 </div>
+	<?php } ?>
 
 </div>

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -105,6 +105,7 @@ class FeatureContext implements Context {
 				'headers' => [
 					'Accept' => 'text/html',
 				],
+				'query' => ['idp' => 1],
 			]
 		);
 	}

--- a/tests/unit/AppInfo/RoutesTest.php
+++ b/tests/unit/AppInfo/RoutesTest.php
@@ -64,6 +64,22 @@ class Test extends TestCase  {
 					'url' => '/saml/selectUserBackEnd',
 					'verb' => 'GET',
 				],
+				[
+					'name' => 'Settings#getSamlProviderSettings',
+					'url' => '/settings/providerSettings/{providerId}',
+					'verb' => 'GET',
+					'defaults' => [
+						'providerId' => '1'
+					]
+				],
+				[
+					'name' => 'Settings#deleteSamlProviderSettings',
+					'url' => '/settings/providerSettings/{providerId}',
+					'verb' => 'DELETE',
+					'defaults' => [
+						'providerId' => '1'
+					]
+				],
 			],
 		];
 		$this->assertSame($expected, $routes);

--- a/tests/unit/Controller/SAMLControllerTest.php
+++ b/tests/unit/Controller/SAMLControllerTest.php
@@ -106,7 +106,7 @@ class SAMLControllerTest extends TestCase  {
 			->method('getAppValue')
 			->with('user_saml', 'type')
 			->willReturn('UnknownValue');
-		$this->samlController->login();
+		$this->samlController->login(1);
 	}
 
 	public function testLoginWithEnvVariableAndNotExistingUidInSettingsArray() {
@@ -135,7 +135,7 @@ class SAMLControllerTest extends TestCase  {
 			->willReturn('https://nextcloud.com/notProvisioned/');
 
 		$expected = new RedirectResponse('https://nextcloud.com/notProvisioned/');
-		$this->assertEquals($expected, $this->samlController->login());
+		$this->assertEquals($expected, $this->samlController->login(1));
 	}
 
 
@@ -185,7 +185,7 @@ class SAMLControllerTest extends TestCase  {
 			->method('updateLastLoginTimestamp');
 
 		$expected = new RedirectResponse('https://nextcloud.com/absolute/');
-		$this->assertEquals($expected, $this->samlController->login());
+		$this->assertEquals($expected, $this->samlController->login(1));
 	}
 
 	public function testLoginWithEnvVariableAndExistingUserAndArray() {
@@ -234,7 +234,7 @@ class SAMLControllerTest extends TestCase  {
 			->willReturn('https://nextcloud.com/absolute/');
 
 		$expected = new RedirectResponse('https://nextcloud.com/absolute/');
-		$this->assertEquals($expected, $this->samlController->login());
+		$this->assertEquals($expected, $this->samlController->login(1));
 	}
 
 	public function testLoginWithEnvVariableAndNotExistingUserWithProvisioning() {
@@ -291,7 +291,7 @@ class SAMLControllerTest extends TestCase  {
 			->method('updateLastLoginTimestamp');
 
 		$expected = new RedirectResponse('https://nextcloud.com/absolute/');
-		$this->assertEquals($expected, $this->samlController->login());
+		$this->assertEquals($expected, $this->samlController->login(1));
 	}
 
 	public function testLoginWithEnvVariableAndNotExistingUserWithMalfunctioningBackend() {
@@ -343,7 +343,7 @@ class SAMLControllerTest extends TestCase  {
 			->willReturn(null);
 
 		$expected = new RedirectResponse('https://nextcloud.com/notprovisioned/');
-		$this->assertEquals($expected, $this->samlController->login());
+		$this->assertEquals($expected, $this->samlController->login(1));
 	}
 
 	public function testLoginWithEnvVariableAndNotExistingUserWithoutProvisioning() {
@@ -382,7 +382,7 @@ class SAMLControllerTest extends TestCase  {
 			->willReturn(false);
 
 		$expected = new RedirectResponse('https://nextcloud.com/notprovisioned/');
-		$this->assertEquals($expected, $this->samlController->login());
+		$this->assertEquals($expected, $this->samlController->login(1));
 	}
 
 	public function testLoginWithEnvVariableAndNotYetMappedUserWithoutProvisioning() {
@@ -433,7 +433,7 @@ class SAMLControllerTest extends TestCase  {
 			->willReturn('MyUid');
 
 		$expected = new RedirectResponse('https://nextcloud.com/absolute/');
-		$this->assertEquals($expected, $this->samlController->login());
+		$this->assertEquals($expected, $this->samlController->login(1));
 	}
 
 	public function testNotProvisioned() {
@@ -466,11 +466,7 @@ class SAMLControllerTest extends TestCase  {
 	 * @param string $expected
 	 */
 	public function testGetSSODisplayName($configuredDisplayName, $expected) {
-		$this->config->expects($this->any())->method('getAppValue')
-			->with('user_saml', 'general-idp0_display_name')
-			->willReturn($configuredDisplayName);
-
-		$result = $this->invokePrivate($this->samlController, 'getSSODisplayName');
+		$result = $this->invokePrivate($this->samlController, 'getSSODisplayName', [$configuredDisplayName]);
 
 		$this->assertSame($expected, $result);
 	}

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -137,7 +137,7 @@ class AdminTest extends \Test\TestCase  {
 			'security-required' => $securityRequiredFields,
 			'security-general' => $securityGeneral,
 			'general' => $generalSettings,
-			'attributeMappings' => $attributeMappingSettings,
+			'attribute-mapping' => $attributeMappingSettings,
 			'providers' => [
 				['id' => 1, 'name' => 'Provider 1'],
 				['id' => 2, 'name' => 'Provider 2']

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -94,14 +94,18 @@ class AdminTest extends \Test\TestCase  {
 			'require_provisioned_account' => [
 				'text' => 'Only allow authentication if an account exists on some other backend. (e.g. LDAP)',
 				'type' => 'checkbox',
+				'global' => true,
 			],
 			'use_saml_auth_for_desktop' => [
 				'text' => 'Use SAML auth for the Nextcloud desktop clients (requires user re-authentication)',
 				'type' => 'checkbox',
+				'global' => true,
 			],
 			'allow_multiple_user_back_ends' => [
 				'text' => $this->l10n->t('Allow the use of multiple user back-ends (e.g. LDAP)'),
 				'type' => 'checkbox',
+				'global' => true,
+				'hideForEnv' => true,
 			],
 		];
 		$attributeMappingSettings = [
@@ -134,6 +138,10 @@ class AdminTest extends \Test\TestCase  {
 			'security-general' => $securityGeneral,
 			'general' => $generalSettings,
 			'attributeMappings' => $attributeMappingSettings,
+			'providers' => [
+				1 => 'Provider 1',
+				2 => 'Provider 2'
+			],
 		];
 
 		return $params;
@@ -141,7 +149,20 @@ class AdminTest extends \Test\TestCase  {
 
 	public function testGetFormWithoutType() {
 		$this->config
-			->expects($this->once())
+			->expects($this->at(0))
+			->method('getAppValue')
+			->with('user_saml', 'providerIds')
+			->willReturn('1,2');
+		$this->config
+			->expects($this->at(1))
+			->method('getAppValue')
+			->willReturn('Provider 1');
+		$this->config
+			->expects($this->at(2))
+			->method('getAppValue')
+			->willReturn('Provider 2');
+		$this->config
+			->expects($this->at(3))
 			->method('getAppValue')
 			->with('user_saml', 'type')
 			->willReturn('');
@@ -155,15 +176,28 @@ class AdminTest extends \Test\TestCase  {
 	}
 
 	public function testGetFormWithSaml() {
+		$this->config
+			->expects($this->at(0))
+			->method('getAppValue')
+			->with('user_saml', 'providerIds')
+			->willReturn('1,2');
+		$this->config
+			->expects($this->at(1))
+			->method('getAppValue')
+			->willReturn('Provider 1');
+		$this->config
+			->expects($this->at(2))
+			->method('getAppValue')
+			->willReturn('Provider 2');
+		$this->config
+			->expects($this->at(3))
+			->method('getAppValue')
+			->with('user_saml', 'type')
+			->willReturn('saml');
 		$this->defaults
 			->expects($this->once())
 			->method('getName')
 			->willReturn('Nextcloud');
-		$this->config
-			->expects($this->once())
-			->method('getAppValue')
-			->with('user_saml', 'type')
-			->willReturn('saml');
 
 		$params = $this->formDataProvider();
 		$params['type'] = 'saml';

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -139,8 +139,8 @@ class AdminTest extends \Test\TestCase  {
 			'general' => $generalSettings,
 			'attributeMappings' => $attributeMappingSettings,
 			'providers' => [
-				1 => 'Provider 1',
-				2 => 'Provider 2'
+				['id' => 1, 'name' => 'Provider 1'],
+				['id' => 2, 'name' => 'Provider 2']
 			],
 		];
 

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\User_SAML\Tests\Settings;
 
+use OCA\User_SAML\SAMLSettings;
 use OCA\User_SAML\UserBackend;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -47,6 +48,8 @@ class UserBackendTest extends TestCase   {
 	private $groupManager;
 	/** @var UserBackend|\PHPUnit_Framework_MockObject_MockObject */
 	private $userBackend;
+	/** @var \PHPUnit_Framework_MockObject_MockObject|SAMLSettings */
+	private $SAMLSettings;
 
 	public function setUp() {
 		parent::setUp();
@@ -57,6 +60,7 @@ class UserBackendTest extends TestCase   {
 		$this->db = $this->createMock(IDBConnection::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->SAMLSettings = $this->getMockBuilder(SAMLSettings::class)->disableOriginalConstructor()->getMock();
 	}
 
 	public function getMockedBuilder(array $mockedFunctions = []) {
@@ -68,7 +72,8 @@ class UserBackendTest extends TestCase   {
 					$this->session,
 					$this->db,
 					$this->userManager,
-					$this->groupManager
+					$this->groupManager,
+					$this->SAMLSettings
 				])
 				->setMethods($mockedFunctions)
 				->getMock();
@@ -79,7 +84,8 @@ class UserBackendTest extends TestCase   {
 				$this->session,
 				$this->db,
 				$this->userManager,
-				$this->groupManager
+				$this->groupManager,
+				$this->SAMLSettings
 			);
 		}
 	}


### PR DESCRIPTION
As discussed with @schiessle this is the frontend part for adding multiple SAML providers. 

![peek 2018-05-13 19-21](https://user-images.githubusercontent.com/3404133/39969919-5bdb1a58-56e3-11e8-9f61-759a7452cf5f.gif)

The config parameters are stored as before for the first provider and prefixed with `ID-` for the others. The list of ids that are configured is available in the app config value of `providerIds`, separated by `,`.

I would guess the following options are only one-time and not per provider:
- Only allow authentication if an account exists on some other backend. (e.g. LDAP)
- Allow the use of multiple user back-ends (e.g. LDAP)
- Use SAML auth for the Nextcloud desktop clients (requires user re-authentication)

Are there any other settings that should be global?

ToDo:
- [x] Implement provider removal
- [x] Make global options independent from individual providers