### PR TITLE
Setting uid as primary key for the table user_saml_users

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -14,6 +14,7 @@
 				<type>text</type>
 				<default></default>
 				<notnull>true</notnull>
+				<primary>true</primary>
 				<length>64</length>
 			</field>
 


### PR DESCRIPTION
Adding a PK for the table (prefix_)user_saml_users  on uid column (user_saml_users::uid).

Aside from enforcing consistency with a primary key it would add some performance gains as PK (and UK) constraint involve an implicit index (in most databases systems).

Also having a primary key (or a non null unique key) on each table is mandatory at least for MySQL Group Replication.

So it would be great if the table has one by default, PR is just one line in database.xml
For my NC 13.0.3 with user_saml 1.50 installation with MySQL, I actually do on the database :  
`ALTER TABLE `nextcloud`.`oc_user_saml_users`  ADD PRIMARY KEY (`uid`);`

