### PR TITLE
we only allow multiple user back ends in combination with SAML, not with environment variables

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -338,7 +338,7 @@ class SAMLController extends Controller {
 
 		if ($this->SAMLSettings->allowMultipleUserBackEnds()) {
 			$loginUrls['directLogin'] = [
-				'url' => $this->getDirectLoginUrl(),
+				'url' => $this->getDirectLoginUrl($redirectUrl),
 				'display-name' => $this->l->t('Direct log in')
 			];
 		}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -88,11 +88,6 @@ class Admin implements ISettings {
 			'lowercaseUrlencoding' =>  $this->l10n->t('ADFS URL-Encodes SAML data as lowercase, and the toolkit by default uses uppercase. Enable for ADFS compatibility on signature verification.'),
 		];
 		$generalSettings = [
-			'idp0_display_name' => [
-				'text' => $this->l10n->t('Optional display name of the identity provider (default: "SSO & SAML log in")'),
-				'type' => 'line',
-				'required' => false,
-			],
 			'uid_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the UID to.'),
 				'type' => 'line',
@@ -102,13 +97,7 @@ class Admin implements ISettings {
 				'text' => $this->l10n->t('Only allow authentication if an account exists on some other backend. (e.g. LDAP)'),
 				'type' => 'checkbox',
 				'global' => true,
-			],
-			'allow_multiple_user_back_ends' => [
-				'text' => $this->l10n->t('Allow the use of multiple user back-ends (e.g. LDAP)'),
-				'type' => 'checkbox',
-				'hideForEnv' => true,
-				'global' => true,
-			],
+			]
 		];
 		$attributeMappingSettings = [
 			'displayName_mapping' => [
@@ -138,6 +127,17 @@ class Admin implements ISettings {
 			$generalSettings['use_saml_auth_for_desktop'] = [
 				'text' => $this->l10n->t('Use SAML auth for the %s desktop clients (requires user re-authentication)', [$this->defaults->getName()]),
 				'type' => 'checkbox',
+				'global' => true,
+			];
+			$generalSettings['idp0_display_name'] = [
+				'text' => $this->l10n->t('Optional display name of the identity provider (default: "SSO & SAML log in")'),
+				'type' => 'line',
+				'required' => false,
+			];
+			$generalSettings['allow_multiple_user_back_ends'] = [
+				'text' => $this->l10n->t('Allow the use of multiple user back-ends (e.g. LDAP)'),
+				'type' => 'checkbox',
+				'hideForEnv' => true,
 				'global' => true,
 			];
 		}

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -15,15 +15,25 @@ style('user_saml', 'admin');
 
 
 	<div class="warning hidden" id="user-saml-warning-admin-user">
-		<?php p(
-			$l->t(
-				'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore, unless you enabled "%s"',
-				[
-					$theme->getEntity(),
-					$_['general']['allow_multiple_user_back_ends']['text']
-				]
-			)
-		)
+		<?php
+		if (isset($_['general']['allow_multiple_user_back_ends']['text'])) {
+			p(
+				$l->t(
+					'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore, unless you enabled "%s"',
+					[
+						$theme->getEntity(),
+						$_['general']['allow_multiple_user_back_ends']['text']
+					]
+				)
+			);
+		} else {
+				$l->t(
+					'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore.',
+					[
+						$theme->getEntity(),
+										]
+				);
+		}
 		?>
 	</div>
 
@@ -42,7 +52,7 @@ style('user_saml', 'admin');
 					<input type="checkbox" data-key="<?php p($key)?>" id="user-saml-general-<?php p($key)?>" name="<?php p($key)?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '0')) ?>">
 					<label for="user-saml-general-<?php p($key)?>"><?php p($attribute['text']) ?></label><br/>
 				</p>
-			<?php elseif($attribute['type'] === 'line' && $attribute['global']): ?>
+			<?php elseif($attribute['type'] === 'line' && isset($attribute['global'])): ?>
 				<p>
 					<input data-key="<?php p($key)?>" name="<?php p($key) ?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '')) ?>" type="text" <?php if(isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
 				</p>
@@ -72,7 +82,7 @@ style('user_saml', 'admin');
 						<input type="checkbox" data-key="<?php p($key)?>" id="user-saml-general-<?php p($key)?>" name="<?php p($key)?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '0')) ?>">
 						<label for="user-saml-general-<?php p($key)?>"><?php p($attribute['text']) ?></label><br/>
 					</p>
-				<?php elseif($attribute['type'] === 'line' && !$attribute['global']): ?>
+				<?php elseif($attribute['type'] === 'line' && !isset($attribute['global'])): ?>
 					<p>
 						<input data-key="<?php p($key)?>" name="<?php p($key) ?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'general-'.$key, '')) ?>" type="text" <?php if(isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
 					</p>

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -169,6 +169,8 @@ class AdminTest extends \Test\TestCase  {
 
 		$params = $this->formDataProvider();
 		unset($params['general']['use_saml_auth_for_desktop']);
+		unset($params['general']['idp0_display_name']);
+		unset($params['general']['allow_multiple_user_back_ends']);
 		$params['type'] = '';
 
 		$expected = new TemplateResponse('user_saml', 'admin', $params);


### PR DESCRIPTION
@juliushaertl found a small bug in the new saml settings. Multiple user back-ends are not supported when environment variables are used for authenticated. Can you have a look at my changes? Thanks!

cc @rullzer for the second review