### PR TITLE
Add reset option

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -69,6 +69,8 @@ switch($config->getAppValue('user_saml', 'type')) {
 	case 'environment-variable':
 		$type = 'environment-variable';
 		break;
+	default:
+		return;
 }
 
 if($returnScript === true) {

--- a/css/admin.css
+++ b/css/admin.css
@@ -54,3 +54,7 @@
 	border-bottom: 1px solid #333;
 	font-weight: bold;
 }
+
+#user-saml-reset-settings {
+	float: right;
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -41,6 +41,16 @@
 			OCP.AppConfig.setValue('user_saml', 'type', 'saml', {success: function() {location.reload();}});
 		},
 
+		resetSettings: function() {
+			if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
+				OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.resetSettings, this));
+				return;
+			}
+
+			OCP.AppConfig.setValue('user_saml', 'type', '', {success: function() {location.reload();}});
+		},
+
+
 		getConfigIdentifier: function() {
 			if (this.currentConfig === '1') {
 				return '';
@@ -153,6 +163,11 @@ $(function() {
 		if(type === '') {
 			OCA.User_SAML.Admin.chooseEnv();
 		}
+	});
+
+	$('#user-saml-reset-settings').click(function(e) {
+		e.preventDefault();
+		OCA.User_SAML.Admin.resetSettings();
 	});
 
 	var switchProvider = function(providerId) {

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -166,6 +166,10 @@ style('user_saml', 'admin');
 		   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('user_saml.SAML.getMetadata', ['idp' => $_['providers'][0]['id']])) ?>" class="button">
 			<?php p($l->t('Download metadata XML')) ?>
 		</a>
+
+		<button id="user-saml-reset-settings"><?php p($l->t('Reset settings')) ?></button>
+
+
 		<span class="warning hidden" id="user-saml-settings-incomplete"><?php p($l->t('Metadata invalid')) ?></span>
 		<span class="success hidden" id="user-saml-settings-complete"><?php p($l->t('Metadata valid')) ?></span>
 	</div>


### PR DESCRIPTION
add a button to reset the config and go back to the initial setup to start over.

To lower the risk that the user will lose the configuration by accident we only remove the "saml type", this is enough to show again the default login screen and let you start the configuration from scratch. But you will stiff have the previous configuration if you chose one of the SSO type