### PR TITLE
make sure that we don't show the "select user back-end login screen if authentication over environment variables has been chosen

### DIFF
--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -80,8 +80,9 @@ class SAMLSettings {
 	 * @return bool
 	 */
 	public function allowMultipleUserBackEnds() {
+		$type = $this->config->getAppValue('user_saml', 'type');
 		$setting = $this->config->getAppValue('user_saml', 'general-allow_multiple_user_back_ends', '0');
-		return  $setting === '1';
+		return  ($setting === '1' && $type === 'saml');
 	}
 
 	/**


### PR DESCRIPTION
make sure that we don't show the "select user back-end login screen if authentication over environment variables has been chosen