### PR TITLE
only call handleApacheAuth() if we login via environment variables

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -53,7 +53,6 @@ $userBackend = new \OCA\User_SAML\UserBackend(
 );
 $userBackend->registerBackends(\OC::$server->getUserManager()->getBackends());
 OC_User::useBackend($userBackend);
-OC_User::handleApacheAuth();
 
 // Setting up the one login config may fail, if so, do not catch the requests later.
 $returnScript = false;
@@ -72,6 +71,10 @@ switch($config->getAppValue('user_saml', 'type')) {
 		break;
 	default:
 		return;
+}
+
+if ($type === 'environment-variable') {
+	OC_User::handleApacheAuth();
 }
 
 if($returnScript === true) {


### PR DESCRIPTION
If the audit-log app is enabled and log level is set to "1". We have multiple failed login attempts in the audit.log during every page reload if the user is logged in via saml. This happens because we always load the app and call `handleApacheAuth()` while this should be only needed for login via environment variables.

With this fix we reduce this "login attempt" messages to one per page reload. The remaining one comes from here https://github.com/nextcloud/server/blob/master/apps/dav/lib/Connector/Sabre/Auth.php#L231. 

````
{"reqId":"vxjRSaLGZJZoU8zcS0tn","level":1,"time":"2018-10-29T22:10:20+00:00","remoteAddr":"127.0.0.1","user":"Schiessle","app":"admin_audit","method":"PROPFIND","url":"\/server\/remote.php\/dav\/files\/Schiessle\/","message":"Login attempt: \"Schiessle\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64; rv:63.0) Gecko\/20100101 Firefox\/63.0","version":"14.0.3.0"}
````

I have no idea how to avoid this one. Any idea?

cc @rullzer 