### PR TITLE
add a combobox instead of buttons to select the login method if more then 4 different IDPs are configured

### DIFF
--- a/js/selectUserBackEnd.js
+++ b/js/selectUserBackEnd.js
@@ -1,0 +1,8 @@
+$(window).load(function() {
+
+	$(document).on('click', 'option', function() {
+		var target = $(this).val();
+		window.location.href = target;
+	});
+
+});

--- a/js/selectUserBackEnd.js
+++ b/js/selectUserBackEnd.js
@@ -2,7 +2,9 @@ $(window).load(function() {
 
 	$(document).on('click', 'option', function() {
 		var target = $(this).val();
-		window.location.href = target;
+		if (target !== '') {
+			window.location.href = target;
+		}
 	});
 
 });

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -366,18 +366,21 @@ class SAMLController extends Controller {
 	 */
 	public function selectUserBackEnd($redirectUrl) {
 
-		$loginUrls = [];
+		$attributes = ['loginUrls' => []];
 
 		if ($this->SAMLSettings->allowMultipleUserBackEnds()) {
-			$loginUrls['directLogin'] = [
+			$attributes['loginUrls']['directLogin'] = [
 				'url' => $this->getDirectLoginUrl($redirectUrl),
 				'display-name' => $this->l->t('Direct log in')
 			];
 		}
 
-		$loginUrls['ssoLogin'] = $this->getIdps($redirectUrl);
+		$attributes['loginUrls']['ssoLogin'] = $this->getIdps($redirectUrl);
 
-		return new Http\TemplateResponse($this->appName, 'selectUserBackEnd', $loginUrls, 'guest');
+		$attributes['useCombobox'] = count($attributes['loginUrls']['ssoLogin']) > 4 ? true : false;
+
+
+		return new Http\TemplateResponse($this->appName, 'selectUserBackEnd', $attributes, 'guest');
 	}
 
 	/**

--- a/templates/selectUserBackEnd.php
+++ b/templates/selectUserBackEnd.php
@@ -1,5 +1,6 @@
 <?php
 style('user_saml', 'selectUserBackEnd');
+script('user_saml', 'selectUserBackEnd');
 
 /** @var array $_ */
 /** @var $l \OCP\IL10N */
@@ -9,16 +10,31 @@ style('user_saml', 'selectUserBackEnd');
 
 <h1>Choose login option:</h1>
 
-	<?php if(isset($_['directLogin'])) : ?>
-<div class="login-option">
-	<a href="<?php p($_['directLogin']['url']); ?>"><?php p($_['directLogin']['display-name']); ?></a>
-</div>
-	<?php endif; ?>
+	<?php if($_['useCombobox']) { ?>
 
-	<?php foreach ($_['ssoLogin'] as $idp) { ?>
-<div class="login-option">
-	<a href="<?php p($idp['url']); ?>"><?php p($idp['display-name']); ?></a>
-</div>
+		<select id="av_mode" name="avMode">
+			<?php foreach ($_['loginUrls']['ssoLogin'] as $idp) { ?>
+				<option value="<?php p($idp['url']); ?>"><?php p($idp['display-name']); ?></option>
+			<?php } ?>
+			<?php if(isset($_['loginUrls']['directLogin'])) : ?>
+				<option value="<?php p($_['loginUrls']['directLogin']['url']); ?>"><?php p($_['loginUrls']['directLogin']['display-name']); ?></option>
+			<?php endif; ?>
+		</select>
+
+	<?php } else { ?>
+
+		<?php if(isset($_['loginUrls']['directLogin'])) : ?>
+			<div class="login-option">
+				<a href="<?php p($_['loginUrls']['directLogin']['url']); ?>"><?php p($_['loginUrls']['directLogin']['display-name']); ?></a>
+			</div>
+		<?php endif; ?>
+
+		<?php foreach ($_['loginUrls']['ssoLogin'] as $idp) { ?>
+			<div class="login-option">
+				<a href="<?php p($idp['url']); ?>"><?php p($idp['display-name']); ?></a>
+			</div>
+		<?php } ?>
+
 	<?php } ?>
 
 </div>

--- a/templates/selectUserBackEnd.php
+++ b/templates/selectUserBackEnd.php
@@ -8,11 +8,12 @@ script('user_saml', 'selectUserBackEnd');
 
 <div id="saml-select-user-back-end">
 
-<h1>Choose login option:</h1>
+<h1>Login options:</h1>
 
 	<?php if($_['useCombobox']) { ?>
 
 		<select id="av_mode" name="avMode">
+			<option value=""><?php p($l->t('Choose a authentication provider')); ?></option>
 			<?php foreach ($_['loginUrls']['ssoLogin'] as $idp) { ?>
 				<option value="<?php p($idp['url']); ?>"><?php p($idp['display-name']); ?></option>
 			<?php } ?>


### PR DESCRIPTION
If you have multipe IDPs the login page looks like this:

![image](https://user-images.githubusercontent.com/1589737/48260331-55d3e480-e41b-11e8-9609-169481e44c7f.png)

This looks nice and is intuitive to use but it doesn't scale for a large number of IDPs, so I made this changes to switch to a combobox if there are more then 4 IDPs configured, in this case it looks like this:

![image](https://user-images.githubusercontent.com/1589737/48260528-05a95200-e41c-11e8-827d-caff4767f841.png)
