### PR TITLE
fix height of select box to select the IDP

### DIFF
--- a/css/selectUserBackEnd.css
+++ b/css/selectUserBackEnd.css
@@ -2,6 +2,10 @@
 	color: var(--color-primary-text);
 }
 
+#saml-select-user-back-end #av_mode{
+	height: auto;
+}
+
 #saml-select-user-back-end h1 {
 	font-size: 16px;
 	padding: 20px 0;


### PR DESCRIPTION
the combobox is to small on Nextcloud 15 to fit in the text. This fixes it.