### PR TITLE
Fix error messages when deleting IDPs

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -96,7 +96,7 @@ class SettingsController extends Controller {
 		];
 		/* Fetch all config values for the given providerId */
 		foreach ($params as $category => $content) {
-			if (empty($content) || $category === 'providers') {
+			if (!is_array($content) || $category === 'providers') {
 				continue;
 			}
 			foreach ($content as $setting => $details) {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -100,7 +100,7 @@ class SettingsController extends Controller {
 				continue;
 			}
 			foreach ($content as $setting => $details) {
-				if ($details['global']) {
+				if (isset($details['global']) && $details['global'] === true) {
 					continue;
 				}
 				$prefix = $providerId === '1' ? '' : $providerId . '-';


### PR DESCRIPTION
Remove error message when deleting IDPs from the setting

- `$content` isn't always an array, in this case the foreach will create an error message in the log. On the other hand doing a "foreach" over an empty array isn't really an issue, so I decided to simplify it as in L99

-  `$details` is not always an array, and the key `global` is not always set, so first test if it exists and then if it is true.

cc @juliushaertl 