### PR TITLE
always create user in the SAML back-end and update the attributes

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -144,7 +144,6 @@ class SAMLController extends Controller {
 				// help with it and make the user known
 				$this->userManager->search($uid);
 				if($this->userManager->userExists($uid)) {
-					$this->userBackend->initializeHomeDir($uid);
 					return;
 				}
 				throw new NoUserFoundException('Auto provisioning not allowed and user ' . $uid . ' does not exist');
@@ -285,7 +284,10 @@ class SAMLController extends Controller {
 			if (!($user instanceof IUser)) {
 				throw new \InvalidArgumentException('User is not valid');
 			}
-			$user->updateLastLoginTimestamp();
+			$firstLogin = $user->updateLastLoginTimestamp();
+			if($firstLogin) {
+				$this->userBackend->initializeHomeDir($user->getUID());
+			}
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app' => $this->appName]);
 			return new Http\RedirectResponse($this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.notProvisioned'));

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -144,6 +144,7 @@ class SAMLController extends Controller {
 				// help with it and make the user known
 				$this->userManager->search($uid);
 				if($this->userManager->userExists($uid)) {
+					$this->userBackend->initializeHomeDir($uid);
 					return;
 				}
 				throw new NoUserFoundException('Auto provisioning not allowed and user ' . $uid . ' does not exist');

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -146,19 +146,28 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 			}
 			$qb->execute();
 
-			### Code taken from lib/private/User/Session.php - function prepareUserLogin() ###
-			//trigger creation of user home and /files folder
-			$userFolder = \OC::$server->getUserFolder($uid);
-			try {
-				// copy skeleton
-				\OC_Util::copySkeleton($uid, $userFolder);
-			} catch (NotPermittedException $ex) {
-				// read only uses
-			}
-			// trigger any other initialization
-			$user = $this->userManager->get($uid);
-			\OC::$server->getEventDispatcher()->dispatch(IUser::class . '::firstLogin', new GenericEvent($user));
+			$this->initializeHomeDir($uid);
+
 		}
+	}
+
+	/**
+	 * @param string $uid
+	 * @throws \OCP\Files\NotFoundException
+	 */
+	public function initializeHomeDir($uid) {
+		### Code taken from lib/private/User/Session.php - function prepareUserLogin() ###
+		//trigger creation of user home and /files folder
+		$userFolder = \OC::$server->getUserFolder($uid);
+		try {
+			// copy skeleton
+			\OC_Util::copySkeleton($uid, $userFolder);
+		} catch (NotPermittedException $ex) {
+			// read only uses
+		}
+		// trigger any other initialization
+		$user = $this->userManager->get($uid);
+		\OC::$server->getEventDispatcher()->dispatch(IUser::class . '::firstLogin', new GenericEvent($user));
 	}
 
 	/**
@@ -227,7 +236,7 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 	/**
 	 * Returns the user's home directory, if home directory mapping is set up.
 	 *
-	 * @param string $uid the username	
+	 * @param string $uid the username
 	 * @return string
 	 */
 	public function getHome($uid) {


### PR DESCRIPTION
create user in the SAML back-end and update the attributes when the user was found on another back-end during login

fix https://github.com/nextcloud/user_saml/issues/268

@maghog @devi69 could you try to apply this two line fix to your installation and report back if this solves the problem? This might also fix https://github.com/nextcloud/user_saml/issues/282