### PR TITLE
Show hint for direct login URL

### DIFF
--- a/templates/admin.php
+++ b/templates/admin.php
@@ -16,23 +16,29 @@ style('user_saml', 'admin');
 
 	<div class="warning hidden" id="user-saml-warning-admin-user">
 		<?php
+		$url = \OC::$server->getURLGenerator()->linkToRouteAbsolute('core.login.showLoginForm') . '?direct=1';
+		$url = '<a href="' . $url . '">' . \OCP\Util::sanitizeHTML($url) . '</a>';
 		if (isset($_['general']['allow_multiple_user_back_ends']['text'])) {
-			p(
+			print_unescaped(
 				$l->t(
-					'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore, unless you enabled "%s"',
+					'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore, unless you enabled "%s" or you go directly to the URL %s.',
 					[
-						$theme->getEntity(),
-						$_['general']['allow_multiple_user_back_ends']['text']
+						\OCP\Util::sanitizeHTML($theme->getEntity()),
+						\OCP\Util::sanitizeHTML($_['general']['allow_multiple_user_back_ends']['text']),
+						$url,
 					]
 				)
 			);
 		} else {
+			print_unescaped(
 				$l->t(
-					'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore.',
+					'Make sure to configure an administrative user that can access the instance via SSO. Logging-in with your regular %s account won\'t be possible anymore, unless you go directly to the URL %s.',
 					[
-						$theme->getEntity(),
-										]
-				);
+						\OCP\Util::sanitizeHTML($theme->getEntity()),
+						$url,
+					]
+				)
+			);
 		}
 		?>
 	</div>


### PR DESCRIPTION
As discussed with @schiessle 

The link was not visible by default so I adjusted the warning box to look like in the screenshots. I will open a server PR soon.

Also the second message wasn't shown at all, because the print was missing 🙈 

![bildschirmfoto 2019-01-18 um 12 05 11](https://user-images.githubusercontent.com/245432/51383410-ab162b80-1b19-11e9-92f9-9ab3f30bce19.png)
![bildschirmfoto 2019-01-18 um 12 05 42](https://user-images.githubusercontent.com/245432/51383411-ab162b80-1b19-11e9-8b0b-31e7afec19d8.png)
