### PR TITLE
Create and merge array from (multi-valued) attributes

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -586,19 +586,8 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 		$value = '';
 		foreach($keys as $key) {
 			if (isset($attributes[$key])) {
-				if (is_array($attributes[$key])) {
-					foreach ($attributes[$key] as $attribute_part_value) {
-						if($value !== '') {
-							$value .= ' ';
-						}
-						$value .= $attribute_part_value;
-					}
-				} else {
-					if($value !== '') {
-						$value .= ' ';
-					}
-					$value .= $attributes[$key];
-				}
+				$array = explode(";", $attributes[$key]);
+				$value = array_merge($value, array_values($array));
 			}
 		}
 


### PR DESCRIPTION
When consuming attributes from headers instead of env, multi-valued attributes are sometimes header name postfixed (_01, _02) or merged using a separator. The former can not easily be solved without extra logic, but the latter can be exploded using the separator character. The advantage is that everything will now be cast into an array, so that values can always be array_merged. Even multi separator-merged-multi-valued attributes will result in the correct multi-valued value this way.

This will solve https://github.com/nextcloud/user_saml/issues/293

TODO: I lack the time and Nextcloud app development experience to introduce a separator setting in UI.
Please add one before merging this PR.
Just make sure to replace an empty separator "" with "\0" so that explode still works and strings aren't unexpectedly cut into smaller pieces. \0 should not naturally occur in strings.