### PR TITLE
Link to portal documentation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,6 +23,9 @@ While theoretically any other authentication provider implementing either one of
 	<types>
 		<authentication/>
 	</types>
+	<documentation>
+		<admin>https://portal.nextcloud.com/article/configuring-single-sign-on-10.html</admin>
+	</documentation>
 	<category>integration</category>
 	<website>https://github.com/nextcloud/user_saml</website>
 	<bugs>https://github.com/nextcloud/user_saml/issues</bugs>


### PR DESCRIPTION
The Nextcloud App Store [listing](https://apps.nextcloud.com/apps/user_saml) for this app continues to point to the URL of the last-seen `<documentation>` tag, which is a dead link.  That behavior is probably a bug in App Store, but we can overwrite the tag with an updated URL to work around it.
Edit: Sorry, this is my first Nextcloud PR, is the below enough to satisfy DCO?  I only figured I'd open the PR rather than comment to ask someone else to do it.
Signed-off-by: mactrent <3249864+mactrent@users.noreply.github.com>