### PR TITLE
Make NameIDFormat configurable

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -244,6 +244,10 @@ $(function() {
 			OCA.User_SAML.Admin.setSamlConfigValue('sp', key, $(this).val());
 		}
 	});
+	$('#user-saml-sp select').change(function(e) {
+		var key = $(this).attr('name');
+		OCA.User_SAML.Admin.setSamlConfigValue('sp', key, $(this).val());
+	});
 
 	$('#user-saml-idp input[type="text"], #user-saml-idp textarea').change(function(e) {
 		var el = $(this);

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -26,6 +26,7 @@ use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;
+use OneLogin\Saml2\Constants;
 
 class SAMLSettings {
 	/** @var IURLGenerator */
@@ -124,6 +125,7 @@ class SAMLSettings {
 				'assertionConsumerService' => [
 					'url' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.assertionConsumerService'),
 				],
+				'NameIDFormat' => $this->config->getAppValue('user_saml', 'sp-name-id-format', Constants::NAMEID_UNSPECIFIED)
 			],
 			'idp' => [
 				'entityId' => $this->config->getAppValue('user_saml', $prefix . 'idp-entityId', ''),

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -28,6 +28,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\Settings\ISettings;
+use OneLogin\Saml2\Constants;
 
 class Admin implements ISettings {
 	/** @var IL10N */
@@ -128,6 +129,46 @@ class Admin implements ISettings {
 
 		];
 
+		$selectedNameIdFormat = $this->config->getAppValue('user_saml', 'sp-name-id-format', Constants::NAMEID_UNSPECIFIED);
+		$nameIdFormats = [
+			Constants::NAMEID_EMAIL_ADDRESS => [
+				'label' => $this->l10n->t('Email address'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_EMAIL_ADDRESS,
+			],
+			Constants::NAMEID_ENCRYPTED => [
+				'label' => $this->l10n->t('Encrypted'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_ENCRYPTED,
+			],
+			Constants::NAMEID_ENTITY => [
+				'label' => $this->l10n->t('Entity'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_ENTITY,
+			],
+			Constants::NAMEID_KERBEROS => [
+				'label' => $this->l10n->t('Kerberos'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_KERBEROS,
+			],
+			Constants::NAMEID_PERSISTENT => [
+				'label' => $this->l10n->t('Persistent'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_PERSISTENT,
+			],
+			Constants::NAMEID_TRANSIENT => [
+				'label' => $this->l10n->t('Transient'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_TRANSIENT,
+			],
+			Constants::NAMEID_UNSPECIFIED => [
+				'label' => $this->l10n->t('Unspecified'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_UNSPECIFIED,
+			],
+			Constants::NAMEID_WINDOWS_DOMAIN_QUALIFIED_NAME => [
+				'label' => $this->l10n->t('Windows domain qualified name'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_WINDOWS_DOMAIN_QUALIFIED_NAME,
+			],
+			Constants::NAMEID_X509_SUBJECT_NAME => [
+				'label' => $this->l10n->t('X509 subject name'),
+				'selected' => $selectedNameIdFormat === Constants::NAMEID_X509_SUBJECT_NAME,
+			],
+		];
+
 		$type = $this->config->getAppValue('user_saml', 'type');
 		if($type === 'saml') {
 			$generalSettings['use_saml_auth_for_desktop'] = [
@@ -155,6 +196,7 @@ class Admin implements ISettings {
 			'security-general' => $securityGeneral,
 			'general' => $generalSettings,
 			'attribute-mapping' => $attributeMappingSettings,
+			'name-id-formats' => $nameIdFormats,
 			'type' => $type,
 			'providers' => $providers
 		];

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -106,6 +106,14 @@ style('user_saml', 'admin');
 			</p>
 
 			<div class="hidden">
+				<label for="user-saml-nameidformat"><?php p($l->t('Name ID format')) ?></label><br/>
+				<select id="user-saml-nameidformat"
+						name="name-id-format">
+					<?php foreach($_['name-id-formats'] as $key => $value): ?>
+					<option value="<?php p($key) ?>"
+						<?php if ($value['selected'] ?? false) { p("selected"); } ?> ><?php p($value['label']) ?></option>
+					<?php endforeach; ?>
+				</select>
 				<?php foreach($_['sp'] as $key => $text): ?>
 					<p>
 						<textarea name="<?php p($key) ?>" placeholder="<?php p($text) ?>"><?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'sp-'.$key, '')) ?></textarea>

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -25,6 +25,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IL10N;
+use OneLogin\Saml2\Constants;
 
 class AdminTest extends \Test\TestCase  {
 	/** @var \OCA\User_SAML\Settings\Admin */
@@ -136,6 +137,45 @@ class AdminTest extends \Test\TestCase  {
 			],
 		];
 
+		$nameIdFormats = [
+			Constants::NAMEID_EMAIL_ADDRESS => [
+				'label' => 'Email address',
+				'selected' => false,
+			],
+			Constants::NAMEID_ENCRYPTED => [
+				'label' => 'Encrypted',
+				'selected' => false,
+			],
+			Constants::NAMEID_ENTITY => [
+				'label' => 'Entity',
+				'selected' => false,
+			],
+			Constants::NAMEID_KERBEROS => [
+				'label' => 'Kerberos',
+				'selected' => false,
+			],
+			Constants::NAMEID_PERSISTENT => [
+				'label' => 'Persistent',
+				'selected' => false,
+			],
+			Constants::NAMEID_TRANSIENT => [
+				'label' => 'Transient',
+				'selected' => false,
+			],
+			Constants::NAMEID_UNSPECIFIED => [
+				'label' => 'Unspecified',
+				'selected' => true,
+			],
+			Constants::NAMEID_WINDOWS_DOMAIN_QUALIFIED_NAME => [
+				'label' => 'Windows domain qualified name',
+				'selected' => false,
+			],
+			Constants::NAMEID_X509_SUBJECT_NAME => [
+				'label' => 'X509 subject name',
+				'selected' => false,
+			],
+		];
+
 		$params = [
 			'sp' => $serviceProviderFields,
 			'security-offer' => $securityOfferFields,
@@ -147,6 +187,7 @@ class AdminTest extends \Test\TestCase  {
 				['id' => 1, 'name' => 'Provider 1'],
 				['id' => 2, 'name' => 'Provider 2']
 			],
+			'name-id-formats' => $nameIdFormats,
 		];
 
 		return $params;
@@ -168,6 +209,11 @@ class AdminTest extends \Test\TestCase  {
 			->willReturn('Provider 2');
 		$this->config
 			->expects($this->at(3))
+			->method('getAppValue')
+			->with('user_saml', 'sp-name-id-format')
+			->will($this->returnArgument(2));
+		$this->config
+			->expects($this->at(4))
 			->method('getAppValue')
 			->with('user_saml', 'type')
 			->willReturn('');
@@ -198,6 +244,11 @@ class AdminTest extends \Test\TestCase  {
 			->willReturn('Provider 2');
 		$this->config
 			->expects($this->at(3))
+			->method('getAppValue')
+			->with('user_saml', 'sp-name-id-format')
+			->will($this->returnArgument(2));
+		$this->config
+			->expects($this->at(4))
 			->method('getAppValue')
 			->with('user_saml', 'type')
 			->willReturn('saml');


### PR DESCRIPTION
Start to make the NameIDFormat configureable (mostly research on how to).

List of possible formats at https://github.com/nextcloud/user_saml/blob/master/3rdparty/vendor/onelogin/php-saml/src/Saml2/Constants.php#L29-L37

Default is unspecified: https://github.com/nextcloud/user_saml/blob/master/3rdparty/vendor/onelogin/php-saml/src/Saml2/Constants.php#L32

Todo:
- [x] Add new field to admin settings under 'Service Provider Data' to select a NameIDFormat
- [x] Store/Retrieve the format properly for the providers
- [x] Set the setting properly: https://github.com/nextcloud/user_saml/compare/enh/name_id_configurable?expand=1#diff-54757ee2ededeca3ef473599e0103481R147
