### PR TITLE
Handle SLO logout requests from IdP via POST

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -49,6 +49,12 @@ return [
 			'verb' => 'GET',
 		],
 		[
+			'name' => 'SAML#singleLogoutService',
+			'url' => '/saml/sls',
+			'verb' => 'POST',
+			'postfix' => 'slspost',
+		],
+		[
 			'name' => 'SAML#notProvisioned',
 			'url' => '/saml/notProvisioned',
 			'verb' => 'GET',

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -319,6 +319,13 @@ class SAMLController extends Controller {
 	public function singleLogoutService() {
 		$isFromGS = ($this->config->getSystemValue('gs.enabled', false) &&
 					 $this->config->getSystemValue('gss.mode', '') === 'master');
+
+		// Some IDPs send the SLO request via POST, but OneLogin php-saml only handles GET.
+		// To hack around this issue we copy the request from _POST to _GET.
+		if(!empty($_POST['SAMLRequest'])) {
+			$_GET['SAMLRequest'] = $_POST['SAMLRequest'];
+		}
+
 		$isFromIDP = !$isFromGS && !empty($_GET['SAMLRequest']);
 
 		if($isFromIDP) {

--- a/tests/unit/AppInfo/RoutesTest.php
+++ b/tests/unit/AppInfo/RoutesTest.php
@@ -55,6 +55,12 @@ class Test extends TestCase  {
 					'verb' => 'GET',
 				],
 				[
+					'name' => 'SAML#singleLogoutService',
+					'url' => '/saml/sls',
+					'verb' => 'POST',
+					'postfix' => 'slspost',
+				],
+				[
 					'name' => 'SAML#notProvisioned',
 					'url' => '/saml/notProvisioned',
 					'verb' => 'GET',


### PR DESCRIPTION
Some IdPs send their SLO logout requests via POST. To handle
them we need to add an entry in the routing table.
Further, we need to hack around the issue, that php-saml only
handles GET by copying the request from $_POST to $_GET.

fix #82

Signed-off-by: Frieder Schrempf <frieder.schrempf@online.de>