### PR TITLE
Fix signing out using IDP because of same site cookies 

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -312,6 +312,7 @@ class SAMLController extends Controller {
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @NoSameSiteCookieRequired
 	 *
 	 * @return Http\RedirectResponse
 	 * @throws Error


### PR DESCRIPTION
Using: Nextcloud master (17) user_saml master and keycloak `4.8.3.Final`.

## Steps to reproduce:

 0. make sure only the IDP is configured as auth backend 
 1. Login on Nextcloud using Keycloak
 2. Go to the account settings of Keycloak e.g. `https://idp/auth/realms/my-realm/account/`
 3. Click the logout button

## Expected

After the #334 and #340 it is expected to be logged out and redirected to the login page of the SSO again.

## Actual Result

You don't get logged out from NC, because you are send from the IDP to NC and requiring same site cookies won't work.
