### PR TITLE
Fix reloading NC after logging out from IDP

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -160,6 +160,7 @@ class SAMLController extends Controller {
 	/**
 	 * @PublicPage
 	 * @UseSession
+	 * @NoCSRFRequired
 	 * @OnlyUnauthenticatedUsers
 	 *
 	 * @param int $idp id of the idp


### PR DESCRIPTION
Related to #345 
Using: Nextcloud master (17) user_saml master and keycloak `4.8.3.Final`.

## Steps to reproduce:

 1. Login on Nextcloud using Keycloak
 2. Go to the account settings of Keycloak e.g. `https://idp/auth/realms/my-realm/account/`
 3. Click the logout button
 4. Reload an existing tab

## Expected

After the #334 and #340 it is expected to be logged out and redirected to the login page of the SSO again.

## Actual Result

You get a redirect loop:

![Selection_0052](https://user-images.githubusercontent.com/2996275/61374646-2a07d900-a89d-11e9-8bd2-13ad37922d9d.png)

The third request doesn't have a valid CRSF token and fails.

