### PR TITLE
Slo redirect to

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -356,9 +356,9 @@ class SAMLController extends Controller {
 				$parameters = array();
 				$nameId = $this->session->get('user_saml.samlNameId');
 				$sessionIndex = $this->session->get('user_saml.samlSessionIndex');
-                if (!empty($_GET['returnTo'])) {
-                        $returnTo = $_GET['returnTo'];
-                }
+				if (!empty($_GET['returnTo'])) {
+					$returnTo = $_GET['returnTo'];
+				}
 				$targetUrl = $auth->logout($returnTo, [], $nameId, $sessionIndex, $stay);
 			}
 			if(!empty($targetUrl) && !$auth->getLastErrorReason()){
@@ -366,11 +366,11 @@ class SAMLController extends Controller {
 			}
 		}
 		if(empty($targetUrl)){
-            if (!empty($_GET['RelayState'])) {
-                    $targetUrl = $_GET['RelayState'];
-            } else {
-                    $targetUrl = $this->urlGenerator->getAbsoluteURL('/');
-            }
+			if (!empty($_GET['RelayState'])) {
+				$targetUrl = $_GET['RelayState'];
+			} else {
+				$targetUrl = $this->urlGenerator->getAbsoluteURL('/');
+			}
 		}
 
 		return new Http\RedirectResponse($targetUrl);

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -356,14 +356,21 @@ class SAMLController extends Controller {
 				$parameters = array();
 				$nameId = $this->session->get('user_saml.samlNameId');
 				$sessionIndex = $this->session->get('user_saml.samlSessionIndex');
-				$targetUrl = $auth->logout(null, [], $nameId, $sessionIndex, $stay);
+                if (!empty($_GET['returnTo'])) {
+                        $returnTo = $_GET['returnTo'];
+                }
+				$targetUrl = $auth->logout($returnTo, [], $nameId, $sessionIndex, $stay);
 			}
 			if(!empty($targetUrl) && !$auth->getLastErrorReason()){
 				$this->userSession->logout();
 			}
 		}
 		if(empty($targetUrl)){
-			$targetUrl = $this->urlGenerator->getAbsoluteURL('/');
+            if (!empty($_GET['RelayState'])) {
+                    $targetUrl = $_GET['RelayState'];
+            } else {
+                    $targetUrl = $this->urlGenerator->getAbsoluteURL('/');
+            }
 		}
 
 		return new Http\RedirectResponse($targetUrl);


### PR DESCRIPTION
### Szenario
I have a nextcloud server and a discourse server. The discourse server authenticates through it's own SSO mechanism with nextcloud using the discoursesso app for nextcloud (maintained by me). Nextcloud itself authenticates using SAML against a SimpleSAMLPhp IDP. 

Everything works just fine, except the logout. When the user hits logout in discourse it redirects to the logout endpoint of the discoursesso app, which then redirects to the SAML logout URL of the user_saml app. Then the SLO process is taking place, but at the end the user is redirected to the nextcloud URL. 

### Expected behaviour
The user should be redirected to the discourse URL (where the logout request came from).

### Actual behaviour
After the SAML SLO procedure is finished the user is redirected to '/', meaning the cloud base URL. 

### Explaination
This can of course not be done by the user_saml app, because the logout request comes from discourse to the discoursesso app, which the redirects to the logout URL, so user_saml does not know about the origin. But the discoursesso app would be able to pass a redirectTo parameter to the user_saml app with the logout URL. 

e.g.: `https://cloud.habidat.local/apps/user_saml/saml/sls?requesttoken=aY.......D&returnTo=https://discourse.example.org`

With a simple patch the SAMLController.php could then pass the returnTo as a RelayState to $auth->logout and after the SLO response from the Idp is received it can redirect to the url using the RelayState parameter the Idp passes along. 

I'm not 100% sure about side effects, as my knowledge of all the SAML use cases is limited and some my be affected by this. Maybe you guys have the knowledge to assess the side affects?