### PR TITLE
fixed login with chrome browser

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -163,6 +163,7 @@ class SAMLController extends Controller {
 	 * @PublicPage
 	 * @UseSession
 	 * @OnlyUnauthenticatedUsers
+	 * @NoCSRFRequired
 	 *
 	 * @param int $idp id of the idp
 	 * @return Http\RedirectResponse


### PR DESCRIPTION
- fix 'environment-variable' login problem with chrome browser
- problem: using nextcloud behind apache2 mod_auth_mellon, chrome browser gets too many redirects
- description: nc_sameSiteCookiestrict is not sent by chrome, because of the origin POST request by idp and the 3xx redirects on nextcloud side