### PR TITLE
Add setting to specify a different signature algorithm

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -322,6 +322,18 @@ $(function() {
 		});
 	});
 
+	$('#user-saml-security input[type="text"], #user-saml-security textarea').change(function(e) {
+		var el = $(this);
+		$.when(el.focusout()).then(function() {
+			var key = $(this).attr('name');
+			OCA.User_SAML.Admin.setSamlConfigValue('security', key, $(this).val());
+		});
+		if (e.keyCode === 13) {
+			var key = $(this).attr('name');
+			OCA.User_SAML.Admin.setSamlConfigValue('security', key, $(this).val());
+		}
+	});
+
 	$('#user-saml-attribute-mapping input[type="text"], #user-saml-attribute-mapping textarea').change(function(e) {
 		var el = $(this);
 		$.when(el.focusout()).then(function() {

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -119,6 +119,7 @@ class SAMLSettings {
 				'wantXMLValidation' => ($this->config->getAppValue('user_saml', $prefix . 'security-wantXMLValidation', '0') === '1') ? true : false,
 				'requestedAuthnContext' => false,
 				'lowercaseUrlencoding' => ($this->config->getAppValue('user_saml', $prefix . 'security-lowercaseUrlencoding', '0') === '1') ? true : false,
+				'signatureAlgorithm' => $this->config->getAppValue('user_saml', $prefix . 'security-signatureAlgorithm', null)
 			],
 			'sp' => [
 				'entityId' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.getMetadata'),

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -75,7 +75,7 @@ class Admin implements ISettings {
 			'authnRequestsSigned' => $this->l10n->t('Indicates whether the <samlp:AuthnRequest> messages sent by this SP will be signed. [Metadata of the SP will offer this info]'),
 			'logoutRequestSigned' => $this->l10n->t('Indicates whether the  <samlp:logoutRequest> messages sent by this SP will be signed.'),
 			'logoutResponseSigned' => $this->l10n->t('Indicates whether the  <samlp:logoutResponse> messages sent by this SP will be signed.'),
-			'signMetadata' => $this->l10n->t('Whether the metadata should be signed.'),
+			'signMetadata' => $this->l10n->t('Whether the metadata should be signed.')
 		];
 		$securityRequiredFields = [
 			'wantMessagesSigned' => $this->l10n->t('Indicates a requirement for the <samlp:Response>, <samlp:LogoutRequest> and <samlp:LogoutResponse> elements received by this SP to be signed.'),
@@ -87,6 +87,10 @@ class Admin implements ISettings {
 		];
 		$securityGeneral = [
 			'lowercaseUrlencoding' =>  $this->l10n->t('ADFS URL-Encodes SAML data as lowercase, and the toolkit by default uses uppercase. Enable for ADFS compatibility on signature verification.'),
+			'signatureAlgorithm' => [
+				'type' => 'line',
+				'text' => $this->l10n->t('Algorithm that the toolkit will use on signing process.')
+			]
 		];
 		$generalSettings = [
 			'uid_mapping' => [

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -177,11 +177,20 @@ style('user_saml', 'admin');
 					</p>
 				<?php endforeach; ?>
 				<h4><?php p($l->t('General')) ?></h4>
-				<?php foreach($_['security-general'] as $key => $text): ?>
-					<p>
-						<input type="checkbox" id="user-saml-<?php p($key)?>" name="<?php p($key)?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'security-'.$key, '0')) ?>" class="checkbox">
-						<label for="user-saml-<?php p($key)?>"><?php p($text) ?></label>
-					</p>
+				<?php foreach($_['security-general'] as $key => $attribute): ?>
+					<?php if (is_array($attribute) && $attribute['type'] === 'line') { ?>
+						<?php $text = $attribute['text'] ?>
+						<p>
+							<label><?php p($attribute['text']) ?></label><br />
+							<input data-key="<?php p($key)?>" name="<?php p($key) ?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'security-'.$key, '')) ?>" type="text" <?php if(isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+						</p>
+					<?php } else { ?>
+						<?php $text = $attribute ?>
+						<p>
+							<input type="checkbox" id="user-saml-<?php p($key)?>" name="<?php p($key)?>" value="<?php p(\OC::$server->getConfig()->getAppValue('user_saml', 'security-'.$key, '0')) ?>" class="checkbox">
+							<label for="user-saml-<?php p($key)?>"><?php p($text) ?></label><br/>
+						</p>
+					<?php } ?>
 				<?php endforeach; ?>
 			</div>
 		</div>

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -80,6 +80,10 @@ class AdminTest extends \Test\TestCase  {
 		];
 		$securityGeneral = [
 			'lowercaseUrlencoding' => 'ADFS URL-Encodes SAML data as lowercase, and the toolkit by default uses uppercase. Enable for ADFS compatibility on signature verification.',
+			'signatureAlgorithm' => [
+				'type' => 'line',
+				'text' => 'Algorithm that the toolkit will use on signing process.'
+			]
 		];
 		$generalSettings = [
 			'idp0_display_name' => [


### PR DESCRIPTION
Add a separate setting for selecting a different signature algorithm.

@rullzer Sorry to disappoint you a bit with no vue rewrite yet, but I've put it on my list of things for some fun hacking :wink: 

Fixes #310 

The list of possible values is defined in [php-saml](https://github.com/onelogin/php-saml):

        http://www.w3.org/2000/09/xmldsig#rsa-sha1
        http://www.w3.org/2000/09/xmldsig#dsa-sha1
        http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
        http://www.w3.org/2001/04/xmldsig-more#rsa-sha384
        http://www.w3.org/2001/04/xmldsig-more#rsa-sha512