### PR TITLE
Better redirect user to homepage instead of showing wired error

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -246,7 +246,7 @@ class SAMLController extends Controller {
 		$AuthNRequestID = $this->session->get('user_saml.AuthNRequestID');
 		$idp = $this->session->get('user_saml.Idp');
 		if(is_null($AuthNRequestID) || $AuthNRequestID === '' || is_null($idp)) {
-			return;
+			new Http\RedirectResponse(\OC::$server->getURLGenerator()->getAbsoluteURL('/'));
 		}
 
 		$auth = new Auth($this->SAMLSettings->getOneLoginSettingsArray($idp));


### PR DESCRIPTION
Empty return displays only the word "null" in the browser. Users who
land here in case of an error are completely lost. We should better
redirect to the homepage in this case.

Signed-off-by: Maximilian Ruta <mr@xtain.net>