### PR TITLE
Handle failing SLO

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -406,7 +406,12 @@ class SAMLController extends Controller {
 				$nameIdNameQualifier = $this->session->get('user_saml.samlNameIdNameQualifier');
 				$nameIdSPNameQualifier = $this->session->get('user_saml.samlNameIdSPNameQualifier');
 				$sessionIndex = $this->session->get('user_saml.samlSessionIndex');
-				$targetUrl = $auth->logout(null, [], $nameId, $sessionIndex, $stay, $nameIdFormat, $nameIdNameQualifier, $nameIdSPNameQualifier);
+				try {
+					$targetUrl = $auth->logout(null, [], $nameId, $sessionIndex, $stay, $nameIdFormat, $nameIdNameQualifier, $nameIdSPNameQualifier);
+				} catch (Error $e) {
+					$this->logger->logException($e, ['level' => ILogger::WARN]);
+					$this->userSession->logout();
+				}
 			}
 			if(!empty($targetUrl) && !$auth->getLastErrorReason()){
 				$this->userSession->logout();


### PR DESCRIPTION
If the SLO throws an error we should catch it. This is so that we do not
show an error page. We should also still logout the current session.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>