### PR TITLE
Fix login flow with SAML

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ While theoretically any other authentication provider implementing either one of
 	<screenshot>https://raw.githubusercontent.com/nextcloud/user_saml/master/screenshots/1.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/user_saml/master/screenshots/2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="20" max-version="20" />
+		<nextcloud min-version="20" max-version="21" />
 	</dependencies>
 	<commands>
 		<command>OCA\User_SAML\Command\GetMetadata</command>


### PR DESCRIPTION
Because of the strict samesite cookies SAML fails with the login flow.
Because the post that comes back is not transfering the proper cookies
to use the same session. Hence the token in use gets lost etc.

Now we store this all (encrypted) in a cookie. So that when we come back
we can restore the proper session.

FAQ:

* Is it elegant?
  Nope!
* Does it work?
  Yes!

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>