### PR TITLE
Fix incorrect key name in "Login flow fix"

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -193,7 +193,7 @@ class SAMLController extends Controller {
 					$flowData['cf1'] = $this->session->get(ClientFlowLoginController::STATE_NAME);
 				} else if ($this->session->get(ClientFlowLoginV2Controller::TOKEN_NAME) !== null) {
 					$flowData['cf2'] = [
-						'name' => $this->session->get(ClientFlowLoginV2Controller::TOKEN_NAME),
+						'token' => $this->session->get(ClientFlowLoginV2Controller::TOKEN_NAME),
 						'state' => $this->session->get(ClientFlowLoginV2Controller::STATE_NAME),
 					];
 				}


### PR DESCRIPTION
'name' key was put in flowData table, but 'token' key was retrieved from this table, thus triggering the following error:
Undefined index: token at /nextcloud/apps/user_saml/lib/Controller/SAMLController.php#306

Signed-off-by: orandev <63342732+orandev@users.noreply.github.com>