### PR TITLE
fix missing user_saml.Idp session value which SAMLSettings rely on

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -351,6 +351,7 @@ $(function() {
 			// Checks on each request whether the settings make sense or not
 			$.ajax({
 				url: OC.generateUrl('/apps/user_saml/saml/metadata'),
+				data: { idp: OCA.User_SAML.Admin.getConfigIdentifier() },
 				type: 'GET'
 			}).fail(function (e) {
 				if (e.status === 500) {

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -311,6 +311,8 @@ class SAMLController extends Controller {
 
 		$AuthNRequestID = $data['AuthNRequestID'];
 		$idp = $data['Idp'];
+		// need to keep the IdP config ID during session lifetime (SAMLSettings::getPrefix)
+		$this->session->set('user_saml.Idp', $idp);
 		if(is_null($AuthNRequestID) || $AuthNRequestID === '' || is_null($idp)) {
 			$this->logger->debug('Invalid auth payload', ['app' => 'user_saml']);
 			return new Http\RedirectResponse($this->urlGenerator->getAbsoluteURL('/'));


### PR DESCRIPTION
quick fix candidate for a regression introduced in https://github.com/nextcloud/user_saml/pull/430

To figure out the correct settings to fetch during session lifetime, `SAMLSettings::getPrefix` relies on the presence of the session stored value that got lost here. 

* [x] draft, because i have not tested it much yet