### PR TITLE
[stable-3.2] Fix incorrect key name in "Login flow fix"

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -193,7 +193,7 @@ class SAMLController extends Controller {
 					$flowData['cf1'] = $this->session->get('client.flow.state.token');
 				} else if ($this->session->get('client.flow.v2.login.token') !== null) {
 					$flowData['cf2'] = [
-						'name' => $this->session->get('client.flow.v2.login.token'),
+						'token' => $this->session->get('client.flow.v2.login.token'),
 						'state' => $this->session->get('client.flow.v2.state.token'),
 					];
 				}


### PR DESCRIPTION
backport of #468 

difference is that consts from `ClientFlowLoginV2Controller` are not used in stable-3.2