### PR TITLE
Always use primary color for buttons

### DIFF
--- a/css/selectUserBackEnd.css
+++ b/css/selectUserBackEnd.css
@@ -12,7 +12,7 @@
 }
 
 .login-option {
-	background-color: var(--color-primary-element);
+	background-color: var(--color-primary);
 	border: 1px solid var(--color-primary-text);
 	font-weight: 600;
 	height: 40px;


### PR DESCRIPTION
Otherwise the big gray buttons look odd on very bright theming colors:

Before:

![image](https://user-images.githubusercontent.com/3404133/100880608-351cd280-34ad-11eb-8f8f-9a3d7c4a07e7.png)


After:

![image](https://user-images.githubusercontent.com/3404133/100880539-2504f300-34ad-11eb-900e-4d98a3ea66ce.png)
