### PR TITLE
support for encryption

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -130,7 +130,11 @@ class Admin implements ISettings {
 				'type' => 'line',
 				'required' => true,
 			],
-
+			'user_secret_mapping' => [
+				'text' => $this->l10n->t('Attribute to use as user secret e.g. for the encryption app.'),
+				'type' => 'line',
+				'required' => false,
+			],
 		];
 
 		$selectedNameIdFormat = $this->config->getAppValue('user_saml', 'sp-name-id-format', Constants::NAMEID_UNSPECIFIED);

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -147,6 +147,15 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 			}
 			$qb->execute();
 
+			// If we use per-user encryption the keys must be initialized first
+			$this->loginInitializeKeystore($uid, $attributes);
+
+			$userSecret = $this->getUserSecret($uid, $attributes);
+			if ($userSecret !== null) {
+				// Emit a post login action to initialize the encryption module with the user secret provided by the idp.
+				// Otherwise the homedir cannot be initialized due to uninitialized keystore.
+				\OC_Hook::emit('OC_User', 'post_login', ['run' => true, 'uid' => $uid, 'password' => $userSecret, 'isTokenLogin' => false]);
+			}
 			$this->initializeHomeDir($uid);
 
 		}
@@ -518,6 +527,16 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 		return '';
 	}
 
+	/**
+	 * Optionally returns a stable per-user secret. This secret is for
+	 * instance used to secure file encryption keys.
+	 * @return string|null
+	 * @since 21.0.0
+	 */
+	public function getCurrentUserSecret() {
+		$samlData = $this->session->get('user_saml.samlUserData');
+		return $this->getUserSecret($this->getCurrentUserId(), $samlData);
+	}
 
 	/**
 	 * Backend name to be shown in user management
@@ -614,6 +633,21 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 		}
 
 		return $value;
+	}
+
+	private function getUserSecret($uid, array $attributes) {
+		try {
+			$userSecret = $this->getAttributeValue('saml-attribute-mapping-user_secret_mapping', $attributes);
+			if ($userSecret === '') {
+				$this->logger->debug('Got no user_secret from idp', ['app' => 'user_saml']);
+			} else {
+				$this->logger->debug('Got user_secret from idp', ['app' => 'user_saml']);
+				return $userSecret;
+			}
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->debug('No user_secret mapping configured', ['app' => 'user_saml']);
+		}
+		return null;
 	}
 
 	public function updateAttributes($uid,

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -139,6 +139,11 @@ class AdminTest extends \Test\TestCase  {
 				'type' => 'line',
 				'required' => true,
 			],
+			'user_secret_mapping' => [
+				'text' => $this->l10n->t('Attribute to use as user secret e.g. for the encryption app.'),
+				'type' => 'line',
+				'required' => false,
+			],
 		];
 
 		$nameIdFormats = [


### PR DESCRIPTION
This allows the idp to return a stable user_secret, which can be
used by e.g. the encryption app in lieu of the password.

We would very, very much like to have this feature in production!

Requires https://github.com/nextcloud/server/pull/24831 to work.

The problem we found is that this app uses `handleApacheAuth()` to initialize the session,
which overrides the encryption app keystore, by emiting
a [login event](https://github.com/nextcloud/server/blob/3a30ac495bd9663ef8233aacc8ce5b21a8adce67/lib/private/legacy/OC_User.php#L180).

We think the easiest approach is to [prevent the key from being overwritten](https://github.com/nextcloud/server/pull/24831).

Let me know if you don't like the approach. An alternative would be to modify `handleApacheAuth` to query the backend for a user secret...

