### PR TITLE
support for per-user encryption

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -130,7 +130,11 @@ class Admin implements ISettings {
 				'type' => 'line',
 				'required' => true,
 			],
-
+			'user_secret_mapping' => [
+				'text' => $this->l10n->t('Attribute to use as user secret e.g. for the encryption app.'),
+				'type' => 'line',
+				'required' => false,
+			],
 		];
 
 		$selectedNameIdFormat = $this->config->getAppValue('user_saml', 'sp-name-id-format', Constants::NAMEID_UNSPECIFIED);

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -139,6 +139,11 @@ class AdminTest extends \Test\TestCase  {
 				'type' => 'line',
 				'required' => true,
 			],
+			'user_secret_mapping' => [
+				'text' => $this->l10n->t('Attribute to use as user secret e.g. for the encryption app.'),
+				'type' => 'line',
+				'required' => false,
+			],
 		];
 
 		$nameIdFormats = [


### PR DESCRIPTION
This allows the idp to return a stable per-user secret, which can be
used by e.g. the encryption app in lieu of the password.

This relies on https://github.com/nextcloud/server/pull/24837
to fetch the secret.