### PR TITLE
Allow customer directlogin text

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -492,9 +492,16 @@ class SAMLController extends Controller {
 		$attributes = ['loginUrls' => []];
 
 		if ($this->SAMLSettings->allowMultipleUserBackEnds()) {
+			$displayName = $this->l->t('Direct log in');
+
+			$customDisplayName = $this->config->getAppValue('user_saml', 'directLoginName', '');
+			if ($customDisplayName !== '') {
+				$displayName = $customDisplayName;
+			}
+
 			$attributes['loginUrls']['directLogin'] = [
 				'url' => $this->getDirectLoginUrl($redirectUrl),
-				'display-name' => $this->l->t('Direct log in')
+				'display-name' => $displayName,
 			];
 		}
 


### PR DESCRIPTION
Some people seem to want to have a custom direct login text. This allows
them to set it. For now only via occ. But maybe some day we also add a
GUI component to it.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>