### PR TITLE
make testEncodedObjectGUID more robust against false positives

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -71,7 +71,7 @@ clone:
 
 steps:
   - name: integration-tests-master
-    image: nextcloudci/user_saml_shibboleth-php7.3:user_saml_shibboleth_php7.3-1
+    image: nextcloudci/user_saml_shibboleth-php7.3:user_saml_shibboleth_php7.3-2
     environment:
       CORE_BRANCH: master
     commands:
@@ -96,36 +96,3 @@ trigger:
 
 type: docker
 
----
-kind: pipeline
-name: integration-tests-stable20
-
-clone:
-  depth: 1
-
-steps:
-  - name: integration-tests-stable20
-    image: nextcloudci/user_saml_shibboleth-php7.2:user_saml_shibboleth_php7.2-3
-    environment:
-      CORE_BRANCH: stable20
-    commands:
-      - /start.sh &
-      - sleep 7
-      - rm -rf /var/www/html
-      - cd /var/www/
-      - git clone --depth 1 -b $CORE_BRANCH https://github.com/nextcloud/server html
-      - cd /var/www/html && git submodule update --init
-      # use local clone
-      - cp -r /drone/src /var/www/html/apps/user_saml
-      - scl enable rh-php72 "bash -c 'php /var/www/html/occ maintenance:install --database sqlite --admin-pass password; php /var/www/html/occ app:enable user_saml'"
-      - chown -R apache:apache /var/www/html/
-      - scl enable rh-php72 "bash -c 'cd /var/www/html/apps/user_saml/tests/integration && vendor/bin/behat'"
-
-trigger:
-  branch:
-    - master
-  event:
-    - pull_request
-    - push
-
-type: docker

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -702,6 +702,11 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 	 *
 	 */
 	public function testEncodedObjectGUID(string $uid): string {
+		if (preg_match('/[^a-zA-Z0-9=+\/]/', $uid) !== 0) {
+			// certainly not encoded
+			return $uid;
+		}
+
 		$candidate = base64_decode($uid, false);
 		if($candidate === false) {
 			return $uid;

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -289,6 +289,8 @@ class UserBackendTest extends TestCase   {
 			['EDE70D16-B9D5-4E9A-ABD7-614D17246E3F', 'EDE70D16-B9D5-4E9A-ABD7-614D17246E3F'],
 			['Tm8gY29udmVyc2lvbgo=', 'Tm8gY29udmVyc2lvbgo='],
 			['ASfjU2OYEd69ZgAVF4pePA==', '53E32701-9863-DE11-BD66-0015178A5E3C'],
+			['aaabbbcc@aa.bbbccdd.eee.ff', 'aaabbbcc@aa.bbbccdd.eee.ff'],
+			['aaabbbcccaa.bbbccdddeee', 'aaabbbcccaa.bbbccdddeee']
 		];
 	}
 


### PR DESCRIPTION
There are some collisions possible. The received string is now tested against allowed characters as put down in https://tools.ietf.org/html/rfc4648#section-4

* [ ] https://github.com/nextcloud/docker-ci/pull/261
* fixes #504 