### PR TITLE
[stable-3.2] make testEncodedObjectGUID more robust against false positives

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -702,6 +702,11 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 	 *
 	 */
 	public function testEncodedObjectGUID(string $uid): string {
+		if (preg_match('/[^a-zA-Z0-9=+\/]/', $uid) !== 0) {
+			// certainly not encoded
+			return $uid;
+		}
+
 		$candidate = base64_decode($uid, false);
 		if($candidate === false) {
 			return $uid;

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -289,6 +289,8 @@ class UserBackendTest extends TestCase   {
 			['EDE70D16-B9D5-4E9A-ABD7-614D17246E3F', 'EDE70D16-B9D5-4E9A-ABD7-614D17246E3F'],
 			['Tm8gY29udmVyc2lvbgo=', 'Tm8gY29udmVyc2lvbgo='],
 			['ASfjU2OYEd69ZgAVF4pePA==', '53E32701-9863-DE11-BD66-0015178A5E3C'],
+			['aaabbbcc@aa.bbbccdd.eee.ff', 'aaabbbcc@aa.bbbccdd.eee.ff'],
+			['aaabbbcccaa.bbbccdddeee', 'aaabbbcccaa.bbbccdddeee']
 		];
 	}
 


### PR DESCRIPTION
backport of #505 