### PR TITLE
Allow setting of "retrieveParametersFromServer"

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -419,9 +419,9 @@ class SAMLController extends Controller {
 			if ($isFromIDP) {
 				$keepLocalSession = true ; // do not let processSLO to delete the entire session. Let userSession->logout do the job
 				$targetUrl = $auth->processSLO(
-					$this->SAMLSettings->usesSloWebServerDecode(),
+					$keepLocalSession,
 					null,
-					false,
+					$this->SAMLSettings->usesSloWebServerDecode(),
 					null,
 					$stay
 				);

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -418,8 +418,14 @@ class SAMLController extends Controller {
 			$stay = true ; // $auth will return the redirect URL but won't perform the redirect himself
 			if ($isFromIDP) {
 				$keepLocalSession = true ; // do not let processSLO to delete the entire session. Let userSession->logout do the job
-				$targetUrl = $auth->processSLO($keepLocalSession, null, false, null, $stay);
-				
+				$targetUrl = $auth->processSLO(
+					$this->SAMLSettings->usesSloWebServerDecode(),
+					null,
+					false,
+					null,
+					$stay
+				);
+
 				$errors = $auth->getErrors();
 				if (!empty($errors)) {
 					foreach($errors as $error) {

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -88,6 +88,10 @@ class SAMLSettings {
 		return  ($setting === '1' && $type === 'saml');
 	}
 
+	public function usesSloWebServerDecode() : bool {
+		return $this->config->getAppValue('user_saml', 'security-sloWebServerDecode', '0') === '1';
+	}
+
 	/**
 	 * get config for given IDP
 	 *

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -90,7 +90,8 @@ class Admin implements ISettings {
 			'signatureAlgorithm' => [
 				'type' => 'line',
 				'text' => $this->l10n->t('Algorithm that the toolkit will use on signing process.')
-			]
+			],
+			'sloWebServerDecode' => $this->l10n->t('Retrieve query parameters from $_SERVER. Some SAML servers require this on SLO requests.'),
 		];
 		$generalSettings = [
 			'uid_mapping' => [

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -83,7 +83,8 @@ class AdminTest extends \Test\TestCase  {
 			'signatureAlgorithm' => [
 				'type' => 'line',
 				'text' => 'Algorithm that the toolkit will use on signing process.'
-			]
+			],
+			'sloWebServerDecode' => 'Retrieve query parameters from $_SERVER. Some SAML servers require this on SLO requests.',
 		];
 		$generalSettings = [
 			'idp0_display_name' => [


### PR DESCRIPTION
Some SAML servers require this type of decoding, otherwise the SLO request fails. Ideally the library would perform both verifications (https://github.com/onelogin/php-saml/issues/466), but it seems upstream doesn't want to perform this change.

Until we have considered a better solution for this, this adds a new checkbox that one can configure.

Ref https://github.com/nextcloud/user_saml/issues/403

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>