### PR TITLE
build and publish services expects user_saml.tar.gz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ appstore: clean
 	--exclude=/tests \
 	--exclude=/translationfiles \
 	$(project_dir)/ $(sign_dir)/$(app_name)
-	tar -czf $(build_dir)/$(app_name)-$(version).tar.gz \
+	tar -czf $(build_dir)/$(app_name).tar.gz \
 		-C $(sign_dir) $(app_name)
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \
 		echo "Signing package…"; \


### PR DESCRIPTION
Takes care of an elipsed occurance in #604 