### PR TITLE
Fix displaying of global checkboxes in user_saml settings

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -186,10 +186,17 @@ class Admin implements ISettings {
 
 		$type = $this->config->getAppValue('user_saml', 'type');
 		if ($type === 'saml') {
+			$generalSettings['require_provisioned_account'] = [
+				'text' => $this->l10n->t('Only allow authentication if an account exists on some other backend (e.g. LDAP).', [$this->defaults->getName()]),
+				'type' => 'checkbox',
+				'global' => true,
+				'value' => $this->config->getAppValue('user_saml', 'general-require_provisioned_account', 0)
+			];
 			$generalSettings['use_saml_auth_for_desktop'] = [
 				'text' => $this->l10n->t('Use SAML auth for the %s desktop clients (requires user re-authentication)', [$this->defaults->getName()]),
 				'type' => 'checkbox',
 				'global' => true,
+				'value' => $this->config->getAppValue('user_saml', 'general-use_saml_auth_for_desktop', 0)
 			];
 			$generalSettings['idp0_display_name'] = [
 				'text' => $this->l10n->t('Optional display name of the identity provider (default: "SSO & SAML log in")'),
@@ -201,6 +208,7 @@ class Admin implements ISettings {
 				'type' => 'checkbox',
 				'hideForEnv' => true,
 				'global' => true,
+				'value' => $this->config->getAppValue('user_saml', 'general-allow_multiple_user_back_ends')
 			];
 		}
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -55,12 +55,12 @@ style('user_saml', 'admin');
 		<?php foreach ($_['general'] as $key => $attribute): ?>
 			<?php if ($attribute['type'] === 'checkbox' && $attribute['global']): ?>
 				<p>
-					<input type="checkbox" data-key="<?php p($key)?>" id="user-saml-general-<?php p($key)?>" name="<?php p($key)?>" value="<?php p($_['config']['general-'.$key] ?? '0') ?>">
+					<input type="checkbox" data-key="<?php p($key)?>" id="user-saml-general-<?php p($key)?>" name="<?php p($key)?>" value="<?php p($attribute['value'] ?? '0') ?>">
 					<label for="user-saml-general-<?php p($key)?>"><?php p($attribute['text']) ?></label><br/>
 				</p>
 			<?php elseif ($attribute['type'] === 'line' && isset($attribute['global'])): ?>
 				<p>
-					<input data-key="<?php p($key)?>" name="<?php p($key) ?>" value="<?php p($_['config']['general-'.$key] ?? '') ?>" type="text" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
+					<input data-key="<?php p($key)?>" name="<?php p($key) ?>" value="<?php p($attribute['value'] ?? '') ?>" type="text" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?> placeholder="<?php p($attribute['text']) ?>"/>
 				</p>
 			<?php endif; ?>
 		<?php endforeach; ?>

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -237,17 +237,25 @@ class AdminTest extends \Test\TestCase {
 				2 => 'Provider 2',
 			]);
 		$this->config
-			->expects($this->once())
+			->expects($this->exactly(4)) # mode + three global values
 			->method('getAppValue')
-			->with('user_saml', 'type')
-			->willReturn('saml');
+			->withConsecutive(
+				['user_saml', 'type'],
+				['user_saml', 'general-require_provisioned_account'],
+				['user_saml', 'general-use_saml_auth_for_desktop'],
+				['user_saml', 'general-allow_multiple_user_back_ends'],
+			)
+			->willReturnOnConsecutiveCalls('saml', 0, 0, '');
 		$this->defaults
-			->expects($this->once())
+			->expects($this->any())
 			->method('getName')
 			->willReturn('Nextcloud');
 
 		$params = $this->formDataProvider();
 		$params['type'] = 'saml';
+		$params['general']['require_provisioned_account']['value'] = 0;
+		$params['general']['use_saml_auth_for_desktop']['value'] = 0;
+		$params['general']['allow_multiple_user_back_ends']['value'] = '';
 
 		$expected = new TemplateResponse('user_saml', 'admin', $params);
 		$this->assertEquals($expected, $this->admin->getForm());


### PR DESCRIPTION
Partly fix problems lined out in #573 
Templated wanted the values in config array, config array is only idp settings from user_saml, not the global ones.
Hope this approach is ok.