### PR TITLE
fix routes to use 1 as default value for idp

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -27,6 +27,10 @@ return [
 			'name' => 'SAML#login',
 			'url' => '/saml/login',
 			'verb' => 'GET',
+			'defaults' => [
+                                'idp' => 1
+                        ],
+
 		],
 		[
 			'name' => 'SAML#base',
@@ -37,11 +41,17 @@ return [
 			'name' => 'SAML#getMetadata',
 			'url' => '/saml/metadata',
 			'verb' => 'GET',
+                        'defaults' => [
+                                'idp' => 1
+                        ],
 		],
 		[
 			'name' => 'SAML#assertionConsumerService',
 			'url' => '/saml/acs',
 			'verb' => 'POST',
+                        'defaults' => [
+                                'idp' => 1
+                        ],
 		],
 		[
 			'name' => 'SAML#singleLogoutService',


### PR DESCRIPTION
Hopefully complete/better attempt to fix sending a value of zero to the SAMLController to get the first idp which was zero before moving config stuff to the DB.

Problems without this:
calling cloud.example.org/apps/user_saml/saml/metadata without ?idp=1 errors
saving anything in Nextcloud settings while having only one IDP configured shows "invalid metadata"
logging in without having two IDPs configured wont work

Fixes https://github.com/nextcloud/user_saml/issues/428 and https://github.com/nextcloud/user_saml/issues/573

I've looked around and it seems every other call to that function has the idp value set to non-empty, so this SHOULD suffice.
Tested it with my setup - works so far as I'm using it.

Signed-off-by: Sascha Markert <markert@b1-systems.de>