### PR TITLE
5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 5.0.2
+### Fixed
+- Fix setup with only one idp by using 1 as default value in routes.
+
 ## 5.0.1
 ### Fixed
 - Direct login silently fails under some circumstances

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ The following providers are supported and tested at the moment:
 	* Any other provider that authenticates using the environment variable
 
 While theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.]]></description>
-	<version>5.0.1</version>
+	<version>5.0.2</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>User_SAML</namespace>


### PR DESCRIPTION
## 5.0.2
### Fixed
- Fix setup with only one idp by using 1 as default value in routes.



Signed-off-by: Max <max@nextcloud.com>