### PR TITLE
No SAML config chooser on env mode

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -156,7 +156,7 @@ if ($useSamlForDesktopClients === '1') {
 
 $multipleUserBackEnds = $samlSettings->allowMultipleUserBackEnds();
 $configuredIdps = $samlSettings->getListOfIdps();
-$showLoginOptions = $multipleUserBackEnds || count($configuredIdps) > 1;
+$showLoginOptions = ($multipleUserBackEnds || count($configuredIdps) > 1) && $type === 'saml';
 
 if ($redirectSituation === true && $showLoginOptions) {
 	try {


### PR DESCRIPTION
- in env mode, only one provider is supported
- choosing any provider would trigger env mode mechanis anyway

The scenario is this: 
1. in SAML settings select "Use build-in SAML authentication" 
2. Configure two or more valid SAML providers
3. In SAML config click "Reset settings" (id does not delete providers, only resets the mode)
4. Now In SAML settings select "Use environment variable" mode, and confiure it
5. In a private window try to log in

Expected is to be logged in automatically. Instead, the provider chooser is presented, but clicking any has no effect as environmental mode is enforced.

This is absolutely a corner case, yet it might save you hours debugging… the same behaviour is present in v4.1.1.
