### PR TITLE
fix signining in with IdPs other than 1

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -27,9 +27,6 @@ return [
 			'name' => 'SAML#login',
 			'url' => '/saml/login',
 			'verb' => 'GET',
-			'defaults' => [
-				'idp' => 1
-			],
 		],
 		[
 			'name' => 'SAML#base',
@@ -40,17 +37,11 @@ return [
 			'name' => 'SAML#getMetadata',
 			'url' => '/saml/metadata',
 			'verb' => 'GET',
-			'defaults' => [
-				'idp' => 1
-			],
 		],
 		[
 			'name' => 'SAML#assertionConsumerService',
 			'url' => '/saml/acs',
 			'verb' => 'POST',
-			'defaults' => [
-				'idp' => 1
-			],
 		],
 		[
 			'name' => 'SAML#singleLogoutService',

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -167,7 +167,7 @@ class SAMLController extends Controller {
 	 * @return Http\RedirectResponse
 	 * @throws \Exception
 	 */
-	public function login($idp) {
+	public function login(int $idp = 1) {
 		$type = $this->config->getAppValue($this->appName, 'type');
 		switch ($type) {
 			case 'saml':
@@ -242,7 +242,7 @@ class SAMLController extends Controller {
 	 * @return Http\DataDownloadResponse
 	 * @throws Error
 	 */
-	public function getMetadata($idp) {
+	public function getMetadata(int $idp = 1) {
 		$settings = new Settings($this->samlSettings->getOneLoginSettingsArray($idp));
 		$metadata = $settings->getSPMetadata();
 		$errors = $settings->validateMetadata($metadata);


### PR DESCRIPTION
fixes #630 

The 'defaults' option in the route configuration is targetted at URL parameters only, but not GET parameters. The [dev docs](https://docs.nextcloud.com/server/latest/developer_manual/basics/routing.html) state:
> defaults (Optional): If this setting is given, a default value will be assumed for each URL parameter which is not present. The default values are passed in as a key => value par array

Therefore the defaults need to be written into the Controller method's signature.