### PR TITLE
fix fetching meta data with IdP id 1

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -60,14 +60,6 @@
 			OCP.AppConfig.setValue('user_saml', 'type', '', {success: function() {location.reload();}});
 		},
 
-
-		getConfigIdentifier: function() {
-			if (this.currentConfig === '1') {
-				return '';
-			}
-			return this.currentConfig + '-';
-		},
-
 		/**
 		 * Add a new provider
 		 */
@@ -131,7 +123,7 @@
 			// Checks on each request whether the settings make sense or not
 			$.ajax({
 				url: OC.generateUrl('/apps/user_saml/saml/metadata'),
-				data: { idp: OCA.User_SAML.Admin.getConfigIdentifier() },
+				data: { idp: this.currentConfig },
 				type: 'GET'
 			}).fail(function (e) {
 				if (e.status === 500) {


### PR DESCRIPTION
When IdP id is 1, the resulting URL is `https://example.org/index.php/apps/user_saml/saml/metadata?idp=` thus setting idp to effectively 0 by presence of the GET parameter, instead of defaulting to 1. Also we only need to provide the id without any other characters, simplifying this a bit.