### PR TITLE
Implementation of Groupbackend II

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,6 +100,12 @@ jobs:
           mkdir data
           ./occ maintenance:install --verbose --database=${{ matrix.databases }} --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           ./occ app:enable --force ${{ env.APP_NAME }}
+          cat << EOF > config/debug.config.php
+          <?php
+          \$CONFIG = [
+            'log.condition' => ['apps' => ['user_saml']],
+          ];
+          EOF
           PHP_CLI_SERVER_WORKERS=4 php -S localhost:8080 &
 
       - name: Run behat

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   phpunit-oci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 6.1.0
+
+### Added
+
+- [Group backend and migration of original SAML groups created as local database groups (user_saml#622)](https://github.com/nextcloud/user_saml/pull/622)
+
 ## 6.0.1
 
 ### Added 

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -20,13 +20,9 @@
  */
 
 use OCA\User_SAML\GroupBackend;
-use OCA\User_SAML\GroupManager;
 use OCA\User_SAML\SAMLSettings;
-use OCP\BackgroundJob\IJobList;
-use OCP\IConfig;
-use OCP\IDBConnection;
+use OCA\User_SAML\UserBackend;
 use OCP\IGroupManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 require_once __DIR__ . '/../3rdparty/vendor/autoload.php';
@@ -55,34 +51,7 @@ $groupBackend = \OC::$server->get(GroupBackend::class);
 
 $samlSettings = \OC::$server->get(SAMLSettings::class);
 
-\OC::$server->registerService(GroupManager::class, function (ContainerInterface $c) use ($groupBackend, $samlSettings) {
-	return new GroupManager(
-		$c->get(IDBConnection::class),
-		$c->get(IGroupManager::class),
-		$groupBackend,
-		$c->get(IConfig::class),
-		$c->get(IJobList::class),
-		$samlSettings,
-	);
-});
-
-$userData = new \OCA\User_SAML\UserData(
-	new \OCA\User_SAML\UserResolver(\OC::$server->getUserManager()),
-	$samlSettings,
-);
-
-$userBackend = new \OCA\User_SAML\UserBackend(
-	$config,
-	$urlGenerator,
-	\OC::$server->getSession(),
-	\OC::$server->getDatabaseConnection(),
-	\OC::$server->getUserManager(),
-	\OC::$server->get(GroupManager::class),
-	$samlSettings,
-	\OCP\Server::get(LoggerInterface::class),
-	$userData,
-	\OC::$server->query(\OCP\EventDispatcher\IEventDispatcher::class),
-);
+$userBackend = \OCP\Server::get(UserBackend::class);
 $userBackend->registerBackends(\OC::$server->getUserManager()->getBackends());
 OC_User::useBackend($userBackend);
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,6 +35,11 @@ While theoretically any other authentication provider implementing either one of
 	<dependencies>
 		<nextcloud min-version="28" max-version="29" />
 	</dependencies>
+	<repair-steps>
+		<post-migration>
+			<step>OCA\User_SAML\Migration\RememberLocalGroupsForPotentialMigrations</step>
+		</post-migration>
+	</repair-steps>
 	<commands>
 		<command>OCA\User_SAML\Command\ConfigCreate</command>
 		<command>OCA\User_SAML\Command\ConfigDelete</command>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ The following providers are supported and tested at the moment:
 	* Any other provider that authenticates using the environment variable
 
 While theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.]]></description>
-	<version>6.0.1</version>
+	<version>6.1.0</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>User_SAML</namespace>

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
 		"nextcloud/coding-standard": "^1.1",
 		"phpunit/phpunit": "^9",
 		"psalm/phar": "^5.13",
-		"nextcloud/ocp": "^27.0"
+		"nextcloud/ocp": "dev-stable27"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b736b5e5d69ab30551c9c38290da5c0a",
+    "content-hash": "41d35031172da5e869aad3ba0557b5c9",
     "packages": [],
     "packages-dev": [
         {
@@ -179,16 +179,16 @@
         },
         {
             "name": "nextcloud/ocp",
-            "version": "v27.0.1",
+            "version": "dev-stable27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "1aaa8b098961a3acadd51b413f7bcfd89f4c0638"
+                "reference": "4b22dae0cacc0e776d4cb83aa4c3b54fea99794a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1aaa8b098961a3acadd51b413f7bcfd89f4c0638",
-                "reference": "1aaa8b098961a3acadd51b413f7bcfd89f4c0638",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/4b22dae0cacc0e776d4cb83aa4c3b54fea99794a",
+                "reference": "4b22dae0cacc0e776d4cb83aa4c3b54fea99794a",
                 "shasum": ""
             },
             "require": {
@@ -217,9 +217,9 @@
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/v27.0.1"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable27"
             },
-            "time": "2023-07-17T09:26:48+00:00"
+            "time": "2023-11-17T00:33:22+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2114,13 +2114,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "nextcloud/ocp": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4"
+        "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/lib/Exceptions/GroupNotFoundException.php
+++ b/lib/Exceptions/GroupNotFoundException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Exceptions;
+
+class GroupNotFoundException extends \RuntimeException {
+}

--- a/lib/Exceptions/NonMigratableGroupException.php
+++ b/lib/Exceptions/NonMigratableGroupException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Exceptions;
+
+class NonMigratableGroupException extends \RuntimeException {
+}

--- a/lib/GroupBackend.php
+++ b/lib/GroupBackend.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Dominik Ach <da@infodatacom.de>
+ *
+ * @author Dominik Ach <da@infodatacom.de>
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ * @author Carl Schwan <carl@carlschwan.eu>
+ * @author Maximilian Ruta <mr@xtain.net>
+ * @author Jonathan Treffler <mail@jonathan-treffler.de>
+ * @author Giuliano Mele <giuliano.mele@verdigado.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML;
+
+use OCP\DB\Exception;
+use OCP\Group\Backend\ABackend;
+use OCP\Group\Backend\IAddToGroupBackend;
+use OCP\Group\Backend\ICountUsersBackend;
+use OCP\Group\Backend\ICreateGroupBackend;
+use OCP\Group\Backend\IDeleteGroupBackend;
+use OCP\Group\Backend\INamedBackend;
+use OCP\Group\Backend\IRemoveFromGroupBackend;
+use OCP\IDBConnection;
+
+class GroupBackend extends ABackend implements IAddToGroupBackend, ICountUsersBackend, ICreateGroupBackend, IDeleteGroupBackend, IRemoveFromGroupBackend, INamedBackend {
+	/** @var IDBConnection */
+	private $dbc;
+
+	/** @var array  */
+	private $groupCache = [];
+
+	public const TABLE_GROUPS = 'user_saml_groups';
+	public const TABLE_MEMBERS = 'user_saml_group_members';
+
+	public function __construct(IDBConnection $dbc) {
+		$this->dbc = $dbc;
+	}
+
+	public function inGroup($uid, $gid): bool {
+		$qb = $this->dbc->getQueryBuilder();
+		$stmt = $qb->select('gid')
+			->from(self::TABLE_MEMBERS)
+			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
+			->andWhere($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
+			->setMaxResults(1)
+			->executeQuery();
+
+		$result = count($stmt->fetchAll()) > 0;
+		$stmt->closeCursor();
+		return $result;
+	}
+
+	/**
+	 * @return string[] Group names
+	 */
+	public function getUserGroups($uid): array {
+		$qb = $this->dbc->getQueryBuilder();
+		$cursor = $qb->select('gid')
+			->from(self::TABLE_MEMBERS)
+			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
+			->executeQuery();
+
+		$groups = [];
+		while ($row = $cursor->fetch()) {
+			$groups[] = $row['gid'];
+			$this->groupCache[$row['gid']] = $row['gid'];
+		}
+		$cursor->closeCursor();
+
+		return $groups;
+	}
+
+	/**
+	 * @return string[] Group names
+	 */
+	public function getGroups($search = '', $limit = null, $offset = null): array {
+		$query = $this->dbc->getQueryBuilder();
+		$query->select('gid')
+			->from(self::TABLE_GROUPS)
+			->orderBy('gid', 'ASC');
+
+		if ($search !== '') {
+			$query->where($query->expr()->iLike('gid', $query->createNamedParameter(
+				'%' . $this->dbc->escapeLikeParameter($search) . '%'
+			)));
+		}
+
+		if ((int)$limit > 0) {
+			$query->setMaxResults((int)$limit);
+		}
+		if ((int)$offset > 0) {
+			$query->setFirstResult((int)$offset);
+		}
+		$result = $query->executeQuery();
+
+		$groups = [];
+		while ($row = $result->fetch()) {
+			$groups[] = $row['gid'];
+		}
+		$result->closeCursor();
+
+		return $groups;
+	}
+
+	/**
+	 * @param string $gid
+	 * @return bool
+	 */
+	public function groupExists($gid): bool {
+		if (isset($this->groupCache[$gid])) {
+			return true;
+		}
+
+		$qb = $this->dbc->getQueryBuilder();
+		$cursor = $qb->select('gid')
+			->from(self::TABLE_GROUPS)
+			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
+			->executeQuery();
+		$result = $cursor->fetch();
+		$cursor->closeCursor();
+
+		if ($result !== false) {
+			$this->groupCache[$gid] = $gid;
+			return true;
+		}
+		return false;
+	}
+
+	public function groupExistsWithDifferentGid(string $samlGid): ?string {
+		$qb = $this->dbc->getQueryBuilder();
+		$cursor = $qb->select('gid')
+			->from(self::TABLE_GROUPS)
+			->where($qb->expr()->eq('saml_gid', $qb->createNamedParameter($samlGid)))
+			->executeQuery();
+		$result = $cursor->fetch(\PDO::FETCH_NUM);
+		$cursor->closeCursor();
+
+		if ($result !== false) {
+			return $result[0];
+		}
+		return null;
+	}
+
+	/**
+	 * @param string $gid
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return string[] User ids
+	 */
+	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0): array {
+		$query = $this->dbc->getQueryBuilder();
+		$query->select('uid')
+			->from(self::TABLE_MEMBERS)
+			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)))
+			->orderBy('uid', 'ASC');
+
+		if ($search !== '') {
+			$query->andWhere($query->expr()->like('uid', $query->createNamedParameter(
+				'%' . $this->dbc->escapeLikeParameter($search) . '%'
+			)));
+		}
+
+		if ($limit !== -1) {
+			$query->setMaxResults($limit);
+		}
+		if ($offset !== 0) {
+			$query->setFirstResult($offset);
+		}
+
+		$result = $query->executeQuery();
+
+		$users = [];
+		while ($row = $result->fetch()) {
+			$users[] = $row['uid'];
+		}
+		$result->closeCursor();
+
+		return $users;
+	}
+
+	public function createGroup(string $gid, string $samlGid = null): bool {
+		try {
+			// Add group
+			$builder = $this->dbc->getQueryBuilder();
+			$samlGid = $samlGid ?? $gid;
+			$result = $builder->insert(self::TABLE_GROUPS)
+				->setValue('gid', $builder->createNamedParameter($gid))
+				->setValue('displayname', $builder->createNamedParameter($samlGid))
+				->setValue('saml_gid', $builder->createNamedParameter($samlGid))
+				->executeStatement();
+		} catch (Exception $e) {
+			if ($e->getReason() === \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				$result = 0;
+			}
+		}
+
+		// Add to cache
+		$this->groupCache[$gid] = $gid;
+
+		return $result === 1;
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function addToGroup(string $uid, string $gid): bool {
+		if ($this->inGroup($uid, $gid)) {
+			return true;
+		}
+
+		$qb = $this->dbc->getQueryBuilder();
+		$qb->insert(self::TABLE_MEMBERS)
+			->setValue('uid', $qb->createNamedParameter($uid))
+			->setValue('gid', $qb->createNamedParameter($gid))
+			->executeStatement();
+		return true;
+	}
+
+	public function removeFromGroup(string $uid, string $gid): bool {
+		$qb = $this->dbc->getQueryBuilder();
+		$rows = $qb->delete(self::TABLE_MEMBERS)
+			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
+			->andWhere($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
+			->executeStatement();
+
+		return $rows > 0;
+	}
+
+	public function countUsersInGroup(string $gid, string $search = ''): int {
+		$query = $this->dbc->getQueryBuilder();
+		$query->select($query->func()->count('*', 'num_users'))
+			->from(self::TABLE_MEMBERS)
+			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)));
+
+		if ($search !== '') {
+			$query->andWhere($query->expr()->like('uid', $query->createNamedParameter(
+				'%' . $this->dbc->escapeLikeParameter($search) . '%'
+			)));
+		}
+
+		$result = $query->executeQuery();
+		$count = $result->fetchOne();
+		$result->closeCursor();
+
+		if ($count !== false) {
+			$count = (int)$count;
+		} else {
+			$count = 0;
+		}
+
+		return $count;
+	}
+
+	public function deleteGroup(string $gid): bool {
+		$query = $this->dbc->getQueryBuilder();
+
+		try {
+			$this->dbc->beginTransaction();
+
+			// delete the group
+			$query->delete(self::TABLE_GROUPS)
+				->where($query->expr()->eq('gid', $query->createNamedParameter($gid)))
+				->executeStatement();
+
+			// delete group user relation
+			$query->delete(self::TABLE_MEMBERS)
+				->where($query->expr()->eq('gid', $query->createNamedParameter($gid)))
+				->executeStatement();
+
+			$this->dbc->commit();
+			unset($this->groupCache[$gid]);
+		} catch (\Throwable $t) {
+			$this->dbc->rollBack();
+			throw $t;
+		}
+
+		return true;
+	}
+
+	public function getBackendName(): string {
+		return 'user_saml';
+	}
+}

--- a/lib/GroupManager.php
+++ b/lib/GroupManager.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Dominik Ach <da@infodatacom.de>
+ *
+ * @author Dominik Ach <da@infodatacom.de>
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ * @author Carl Schwan <carl@carlschwan.eu>
+ * @author Maximilian Ruta <mr@xtain.net>
+ * @author Jonathan Treffler <mail@jonathan-treffler.de>
+ * @author Giuliano Mele <giuliano.mele@verdigado.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML;
+
+use OC\Hooks\PublicEmitter;
+use OCA\User_SAML\Exceptions\GroupNotFoundException;
+use OCA\User_SAML\Exceptions\NonMigratableGroupException;
+use OCA\User_SAML\Jobs\MigrateGroups;
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+
+class GroupManager {
+	public const LOCAL_GROUPS_CHECK_FOR_MIGRATION = 'localGroupsCheckForMigration';
+
+	/**
+	 * @var IDBConnection $db
+	 */
+	protected $db;
+
+	/** @var IGroupManager */
+	private $groupManager;
+	/** @var GroupBackend */
+	private $ownGroupBackend;
+	/** @var IConfig */
+	private $config;
+	/** @var IJobList */
+	private $jobList;
+	/** @var SAMLSettings */
+	private $settings;
+
+
+	public function __construct(
+		IDBConnection $db,
+		IGroupManager $groupManager,
+		GroupBackend $ownGroupBackend,
+		IConfig $config,
+		IJobList $jobList,
+		SAMLSettings $settings
+	) {
+		$this->db = $db;
+		$this->groupManager = $groupManager;
+		$this->ownGroupBackend = $ownGroupBackend;
+		$this->config = $config;
+		$this->jobList = $jobList;
+		$this->settings = $settings;
+	}
+
+	/**
+	 * @param string[] $samlGroupNames
+	 * @param IGroup[] $assignedGroups
+	 * @return string[]
+	 */
+	private function getGroupsToRemove(array $samlGroupNames, array $assignedGroups): array {
+		$groupsToRemove = [];
+		// FIXME: Seems unused
+		$this->config->getAppValue('user_saml', self::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '');
+		foreach ($assignedGroups as $group) {
+			// if group is not supplied by SAML and group has SAML backend
+			if (!in_array($group->getGID(), $samlGroupNames) && $this->hasSamlBackend($group)) {
+				$groupsToRemove[] = $group->getGID();
+			} elseif ($this->mayModifyGroup($group)) {
+				$groupsToRemove[] = $group->getGID();
+			}
+		}
+		return $groupsToRemove;
+	}
+
+	/**
+	 * @param string[] $samlGroupNames
+	 * @param string[] $assignedGroupIds
+	 * @return string[]
+	 */
+	private function getGroupsToAdd(array $samlGroupNames, array $assignedGroupIds): array {
+		$groupsToAdd = [];
+		foreach ($samlGroupNames as $groupName) {
+			$group = $this->groupManager->get($groupName);
+			// if user is not assigned to the group or the provided group has a non SAML backend
+			if (!in_array($groupName, $assignedGroupIds) || !$this->hasSamlBackend($group)) {
+				$groupsToAdd[] = $groupName;
+			} elseif ($this->mayModifyGroup($group)) {
+				$groupsToAdd[] = $group->getGID();
+			}
+		}
+		return $groupsToAdd;
+	}
+
+	public function handleIncomingGroups(IUser $user, array $samlGroupNames): void {
+		$this->updateUserGroups($user, $samlGroupNames);
+		// TODO: drop following line with dropping NC 28 support
+		$this->evaluateGroupMigrations($samlGroupNames);
+	}
+
+	public function updateUserGroups(IUser $user, array $samlGroupNames): void {
+		$this->translateGroupToIds($samlGroupNames);
+		$assignedGroups = $this->groupManager->getUserGroups($user);
+		$assignedGroupIds = array_map(function (IGroup $group) {
+			return $group->getGID();
+		}, $assignedGroups);
+		$groupsToRemove = $this->getGroupsToRemove($samlGroupNames, $assignedGroups);
+		$groupsToAdd = $this->getGroupsToAdd($samlGroupNames, $assignedGroupIds);
+		$this->handleUserUnassignedFromGroups($user, $groupsToRemove);
+		$this->handleUserAssignedToGroups($user, $groupsToAdd);
+	}
+
+	protected function translateGroupToIds(array &$samlGroups): void {
+		array_walk($samlGroups, function (&$gid) {
+			$altGid = $this->ownGroupBackend->groupExistsWithDifferentGid($gid);
+			if ($altGid !== null) {
+				$gid = $altGid;
+			}
+		});
+	}
+
+	protected function handleUserUnassignedFromGroups(IUser $user, array $groupIds): void {
+		foreach ($groupIds as $gid) {
+			$this->unassignUserFromGroup($user, $gid);
+		}
+	}
+
+	protected function unassignUserFromGroup(IUser $user, string $gid): void {
+		$group = $this->groupManager->get($gid);
+		if ($group === null) {
+			return;
+		}
+
+		if ($this->hasSamlBackend($group)) {
+			$this->ownGroupBackend->removeFromGroup($user->getUID(), $group->getGID());
+			if ($this->ownGroupBackend->countUsersInGroup($gid) === 0) {
+				/** @psalm-suppress UndefinedInterfaceMethod */
+				$this->groupManager->emit('\OC\Group', 'preDelete', [$group]);
+				$this->ownGroupBackend->deleteGroup($group->getGID());
+				/** @psalm-suppress UndefinedInterfaceMethod */
+				$this->groupManager->emit('\OC\Group', 'postDelete', [$group]);
+			}
+		} else {
+			$group->removeUser($user);
+		}
+	}
+
+	protected function handleUserAssignedToGroups(IUser $user, $groupIds): void {
+		foreach ($groupIds as $gid) {
+			$this->assignUserToGroup($user, $gid);
+		}
+	}
+
+	protected function assignUserToGroup(IUser $user, string $gid): void {
+		try {
+			$group = $this->findGroup($gid);
+		} catch (GroupNotFoundException $e) {
+			$group = $this->createGroupInBackend($gid);
+		} catch (NonMigratableGroupException $e) {
+			$providerId = $this->settings->getProviderId();
+			$settings = $this->settings->get($providerId);
+			$groupPrefix = $settings['saml-attribute-mapping-group_mapping_prefix'] ?? SAMLSettings::DEFAULT_GROUP_PREFIX;
+			$group = $this->createGroupInBackend($groupPrefix . $gid, $gid);
+		}
+
+		$group->addUser($user);
+	}
+
+	protected function createGroupInBackend(string $gid, ?string $originalGid = null): ?IGroup {
+		if ($this->groupManager instanceof PublicEmitter) {
+			$this->groupManager->emit('\OC\Group', 'preCreate', array($gid));
+		}
+		if (!$this->ownGroupBackend->createGroup($gid, $originalGid ?? $gid)) {
+			return null;
+		}
+
+		$group = $this->groupManager->get($gid);
+		if ($this->groupManager instanceof PublicEmitter) {
+			$this->groupManager->emit('\OC\Group', 'postCreate', array($group));
+		}
+
+		return $group;
+	}
+
+	/**
+	 * @throws GroupNotFoundException|NonMigratableGroupException
+	 */
+	protected function findGroup(string $gid): IGroup {
+		$migrationAllowList = $this->config->getAppValue(
+			'user_saml',
+			GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION,
+			''
+		);
+		$strictBackendCheck = '' === $migrationAllowList;
+		if ($migrationAllowList !== '') {
+			$migrationAllowList = \json_decode($migrationAllowList, true);
+		}
+		if (!$strictBackendCheck && in_array($gid, $migrationAllowList['groups'] ?? [], true)) {
+			$group = $this->groupManager->get($gid);
+			if ($group === null) {
+				throw new GroupNotFoundException();
+			}
+			return $group;
+		}
+		$group = $this->groupManager->get($gid);
+		if ($group === null) {
+			throw new GroupNotFoundException();
+		}
+		if ($this->hasSamlBackend($group)) {
+			return $group;
+		}
+
+		$altGid = $this->ownGroupBackend->groupExistsWithDifferentGid($gid);
+		if ($altGid) {
+			$group = $this->groupManager->get($altGid);
+			if ($group) {
+				return $group;
+			}
+			throw new GroupNotFoundException();
+		}
+
+		throw new NonMigratableGroupException();
+	}
+
+	protected function hasSamlBackend(IGroup $group): bool {
+		return in_array('user_saml', $group->getBackendNames());
+	}
+
+	public function evaluateGroupMigrations(array $groups): void {
+		$candidateInfo = $this->config->getAppValue('user_saml', self::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '');
+		if ($candidateInfo === '') {
+			return;
+		}
+		$candidateInfo = \json_decode($candidateInfo, true);
+		if (!isset($candidateInfo['dropAfter']) || $candidateInfo['dropAfter'] < time()) {
+			$this->config->deleteAppValue('user_saml', self::LOCAL_GROUPS_CHECK_FOR_MIGRATION);
+			return;
+		}
+
+		$this->jobList->add(MigrateGroups::class, ['gids' => $groups]);
+	}
+
+	protected function isGroupInTransitionList(string $groupId): bool {
+		$candidateInfo = $this->config->getAppValue('user_saml', self::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '');
+		if ($candidateInfo === '') {
+			return false;
+		}
+		$candidateInfo = \json_decode($candidateInfo, true);
+		if (!isset($candidateInfo['dropAfter']) || $candidateInfo['dropAfter'] < time()) {
+			$this->config->deleteAppValue('user_saml', self::LOCAL_GROUPS_CHECK_FOR_MIGRATION);
+			return false;
+		}
+
+		return in_array($groupId, $candidateInfo['groups']);
+	}
+
+	protected function hasGroupForeignMembers(IGroup $group): bool {
+		foreach ($group->getUsers() as $user) {
+			if ($user->getBackendClassName() !== 'user_saml') {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * In the transition phase, update group memberships of local groups only
+	 * under very specific conditions. Otherwise, membership modifications are
+	 * allowed only for groups owned by the SAML backend.
+	 */
+	protected function mayModifyGroup(?IGroup $group): bool {
+		return
+			$group !== null
+			&& $group->getGID() !== 'admin'
+			&& in_array('Database', $group->getBackendNames())
+			&& $this->isGroupInTransitionList($group->getGID())
+			&& !$this->hasGroupForeignMembers($group);
+	}
+}

--- a/lib/Jobs/MigrateGroups.php
+++ b/lib/Jobs/MigrateGroups.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Jobs;
+
+use OCA\User_SAML\GroupBackend;
+use OCA\User_SAML\GroupManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class MigrateGroups
+ *
+ * @package OCA\User_SAML\Jobs
+ * @todo: remove this, when dropping Nextcloud 29 support
+ */
+class MigrateGroups extends QueuedJob {
+
+	/** @var IConfig */
+	private $config;
+	/** @var IGroupManager */
+	private $groupManager;
+	/** @var IDBConnection */
+	private $dbc;
+	/** @var GroupBackend */
+	private $ownGroupBackend;
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(
+		IConfig $config,
+		IGroupManager $groupManager,
+		IDBConnection $dbc,
+		GroupBackend $ownGroupBackend,
+		LoggerInterface $logger,
+		ITimeFactory $timeFactory
+	) {
+		parent::__construct($timeFactory);
+		$this->config = $config;
+		$this->groupManager = $groupManager;
+		$this->dbc = $dbc;
+		$this->ownGroupBackend = $ownGroupBackend;
+		$this->logger = $logger;
+	}
+
+	protected function run($argument) {
+		try {
+			$candidates = $this->getMigratableGroups();
+			$toMigrate = $this->getGroupsToMigrate($argument['gids'], $candidates);
+			$migrated = $this->migrateGroups($toMigrate);
+			$this->updateCandidatePool($migrated);
+		} catch (\RuntimeException $e) {
+			return;
+		}
+	}
+
+	protected function updateCandidatePool($migrateGroups) {
+		$candidateInfo = $this->config->getAppValue('user_saml', GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '');
+		if ($candidateInfo === null || $candidateInfo === '') {
+			return;
+		}
+		$candidateInfo = \json_decode($candidateInfo, true);
+		if (!isset($candidateInfo['dropAfter']) || !isset($candidateInfo['groups'])) {
+			return;
+		}
+		$candidateInfo['groups'] = array_diff($candidateInfo['groups'], $migrateGroups);
+		$this->config->setAppValue(
+			'user_saml',
+			GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION,
+			json_encode($candidateInfo)
+		);
+	}
+
+	protected function migrateGroups(array $toMigrate): array {
+		return array_filter($toMigrate, function ($gid) {
+			return $this->migrateGroup($gid);
+		});
+	}
+
+	protected function migrateGroup(string $gid): bool {
+		try {
+			$this->dbc->beginTransaction();
+
+			$qb = $this->dbc->getQueryBuilder();
+			$affected = $qb->delete('groups')
+				->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
+				->executeStatement();
+			if ($affected === 0) {
+				throw new \RuntimeException('Could not delete group from local backend');
+			}
+
+			if (!$this->ownGroupBackend->createGroup($gid)) {
+				throw new \RuntimeException('Could not create group in SAML backend');
+			}
+
+			$this->dbc->commit();
+
+			return true;
+		} catch (\Exception $e) {
+			$this->dbc->rollBack();
+			$this->logger->warning($e->getMessage(), ['app' => 'user_saml', 'exception' => $e]);
+		}
+
+		return false;
+	}
+
+	protected function getGroupsToMigrate(array $samlGroups, array $pool): array {
+		return array_filter($samlGroups, function (string $gid) use ($pool) {
+			if (!in_array($gid, $pool)) {
+				return false;
+			}
+
+			$group = $this->groupManager->get($gid);
+			if ($group === null) {
+				return false;
+			}
+
+			$backendNames = $group->getBackendNames();
+			if (!in_array('Database', $backendNames, true)) {
+				return false;
+			}
+
+			foreach ($group->getUsers() as $user) {
+				if ($user->getBackendClassName() !== 'user_saml') {
+					return false;
+				}
+			}
+
+			return true;
+		});
+	}
+
+	protected function getMigratableGroups(): array {
+		$candidateInfo = $this->config->getAppValue('user_saml', GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '');
+		if ($candidateInfo === null || $candidateInfo === '') {
+			throw new \RuntimeException('No migration of groups to SAML backend anymore');
+		}
+		$candidateInfo = \json_decode($candidateInfo, true);
+		if (!isset($candidateInfo['dropAfter']) || !isset($candidateInfo['groups']) || $candidateInfo['dropAfter'] < time()) {
+			$this->config->deleteAppValue('user_saml', GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION);
+			throw new \RuntimeException('Period for migration groups is over');
+		}
+
+		return $candidateInfo['groups'];
+	}
+}

--- a/lib/Migration/RememberLocalGroupsForPotentialMigrations.php
+++ b/lib/Migration/RememberLocalGroupsForPotentialMigrations.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Migration;
+
+use OC\Group\Database;
+use OCA\User_SAML\GroupManager;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use UnexpectedValueException;
+use function json_encode;
+
+class RememberLocalGroupsForPotentialMigrations implements IRepairStep {
+
+	/** @var IGroupManager */
+	private $groupManager;
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(
+		IGroupManager $groupManager,
+		IConfig $config
+	) {
+		$this->groupManager = $groupManager;
+		$this->config = $config;
+	}
+
+	public function getName(): string {
+		return 'Remember local groups that might belong to SAML';
+	}
+
+	/**
+	 * Run repair step.
+	 * Must throw exception on error.
+	 *
+	 * @param IOutput $output
+	 * @throws \Exception in case of failure
+	 * @since 9.1.0
+	 */
+	public function run(IOutput $output) {
+		try {
+			$backend = $this->findBackend();
+			$groupIds = $this->findGroupIds($backend);
+		} catch (UnexpectedValueException $e) {
+			return;
+		}
+
+		$this->config->setAppValue(
+			'user_saml',
+			GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION,
+			json_encode([
+				'dropAfter' => time() + 86400 * 60, // 60 days
+				'groups' => $groupIds
+			])
+		);
+	}
+
+	protected function findGroupIds(Database $backend): array {
+		$groupIds = $backend->getGroups();
+		$adminGroupIndex = array_search('admin', $groupIds, true);
+		if ($adminGroupIndex !== false) {
+			unset($groupIds[$adminGroupIndex]);
+		}
+		return $groupIds;
+	}
+
+	protected function findBackend(): Database {
+		$groupBackends = $this->groupManager->getBackends();
+		foreach ($groupBackends as $backend) {
+			if ($backend instanceof Database) {
+				return $backend;
+			}
+		}
+		throw new UnexpectedValueException();
+	}
+}

--- a/lib/Migration/Version6000Date20220912152700.php
+++ b/lib/Migration/Version6000Date20220912152700.php
@@ -81,9 +81,9 @@ class Version6000Date20220912152700 extends SimpleMigrationStep {
 				'length' => 64,
 				'default' => '',
 			]);
-			$table->setPrimaryKey(['gid', 'uid'], 'idx_group_members');
-			$table->addIndex(['gid']);
-			$table->addIndex(['uid']);
+			$table->setPrimaryKey(['gid', 'uid'], 'pk_saml_group_members');
+			$table->addIndex(['gid'], 'saml_group_members_gid'); // prefix is added in callee
+			$table->addIndex(['uid'], 'saml_group_members_uid'); // prefix is added in callee
 		}
 		return $schema;
 	}

--- a/lib/Migration/Version6000Date20220912152700.php
+++ b/lib/Migration/Version6000Date20220912152700.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Dominik Ach <da@infodatacom.de>
+ *
+ * @author Dominik Ach <da@infodatacom.de>
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ * @author Carl Schwan <carl@carlschwan.eu>
+ * @author Maximilian Ruta <mr@xtain.net>
+ * @author Jonathan Treffler <mail@jonathan-treffler.de>
+ * @author Giuliano Mele <giuliano.mele@verdigado.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version6000Date20220912152700 extends SimpleMigrationStep {
+
+	/**
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('user_saml_groups')) {
+			$table = $schema->createTable('user_saml_groups');
+			$table->addColumn('gid', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+				'default' => '',
+			]);
+			$table->addColumn('displayname', Types::STRING, [
+				'notnull' => true,
+				'length' => 255,
+				'default' => '',
+			]);
+			$table->addColumn('saml_gid', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+				'default' => '',
+			]);
+			$table->setPrimaryKey(['gid']);
+			$table->addUniqueIndex(['saml_gid']);
+		}
+
+		if (!$schema->hasTable('user_saml_group_members')) {
+			$table = $schema->createTable('user_saml_group_members');
+			$table->addColumn('uid', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+				'default' => '',
+			]);
+			$table->addColumn('gid', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+				'default' => '',
+			]);
+			$table->setPrimaryKey(['gid', 'uid'], 'idx_group_members');
+			$table->addIndex(['gid']);
+			$table->addIndex(['uid']);
+		}
+		return $schema;
+	}
+}

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -25,7 +25,6 @@ use InvalidArgumentException;
 use OCA\User_SAML\Db\ConfigurationsMapper;
 use OCP\DB\Exception;
 use OCP\IConfig;
-use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;
 use OneLogin\Saml2\Constants;
@@ -35,6 +34,10 @@ class SAMLSettings {
 	private const LOADED_CHOSEN = 1;
 	private const LOADED_ALL = 2;
 
+	// list of global settings which are valid for every idp:
+	// 'general-require_provisioned_account', 'general-allow_multiple_user_back_ends', 'general-use_saml_auth_for_desktop'
+
+	// IdP-specific keys
 	public const IDP_CONFIG_KEYS = [
 		'general-idp0_display_name',
 		'general-uid_mapping',
@@ -66,12 +69,15 @@ class SAMLSettings {
 		'saml-attribute-mapping-home_mapping',
 		'saml-attribute-mapping-quota_mapping',
 		'saml-attribute-mapping-mfa_mapping',
+		'saml-attribute-mapping-group_mapping_prefix',
 		'saml-user-filter-reject_groups',
 		'saml-user-filter-require_groups',
 		'sp-x509cert',
 		'sp-name-id-format',
 		'sp-privateKey',
 	];
+
+	public const DEFAULT_GROUP_PREFIX = 'SAML_';
 
 	/** @var IURLGenerator */
 	private $urlGenerator;
@@ -86,12 +92,6 @@ class SAMLSettings {
 	/** @var ConfigurationsMapper */
 	private $mapper;
 
-	/**
-	 * @param IURLGenerator $urlGenerator
-	 * @param IConfig $config
-	 * @param IRequest $request
-	 * @param ISession $session
-	 */
 	public function __construct(
 		IURLGenerator $urlGenerator,
 		IConfig       $config,

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -120,13 +120,13 @@ class Admin implements ISettings {
 				'type' => 'line',
 				'required' => false,
 			],
-			'group_mapping' => [
-				'text' => $this->l10n->t('Attribute to map the users groups to.'),
+			'home_mapping' => [
+				'text' => $this->l10n->t('Attribute to map the users home to.'),
 				'type' => 'line',
 				'required' => true,
 			],
-			'home_mapping' => [
-				'text' => $this->l10n->t('Attribute to map the users home to.'),
+			'group_mapping' => [
+				'text' => $this->l10n->t('Attribute to map the users groups to.'),
 				'type' => 'line',
 				'required' => true,
 			],
@@ -135,7 +135,11 @@ class Admin implements ISettings {
 				'type' => 'line',
 				'required' => false,
 			],
-
+			'group_mapping_prefix' => [
+				'text' => $this->l10n->t('Group Mapping Prefix, default: %s', [SAMLSettings::DEFAULT_GROUP_PREFIX]),
+				'type' => 'line',
+				'required' => true,
+			],
 		];
 
 		$userFilterSettings = [

--- a/tests/integration/features/Shibboleth.feature
+++ b/tests/integration/features/Shibboleth.feature
@@ -93,7 +93,7 @@ Feature: Shibboleth
     And The user value "email" should be "student1@idptestbed.edu"
     And The user value "quota.total" should be "209715200"
     And The user value "display-name" should be "Stud Ent"
-    And The user value "groups" should be "Students, Astrophysics"
+    And The user value "groups" should be "SAML_Astrophysics,SAML_Students"
     And the group "SAML_Astrophysics" should exists
     And the group "SAML_Students" should exists
     And The last login timestamp of "student1" should not be empty

--- a/tests/integration/features/Shibboleth.feature
+++ b/tests/integration/features/Shibboleth.feature
@@ -63,7 +63,7 @@ Feature: Shibboleth
     And The response should be a SAML redirect page that gets submitted
     And I should be redirected to "http://localhost:8080/index.php/apps/dashboard/"
     Then The user value "id" should be "student1"
-    Then The user value "email" should be ""
+    And The user value "email" should be ""
     And The user value "display-name" should be "Default displayname of student1"
     And The last login timestamp of "student1" should not be empty
 
@@ -80,6 +80,8 @@ Feature: Shibboleth
     And The setting "security-wantAssertionsSigned" is set to "1"
     And The setting "saml-attribute-mapping-email_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.3"
     And The setting "saml-attribute-mapping-displayName_mapping" is set to "urn:oid:2.5.4.42 urn:oid:2.5.4.4"
+    And The setting "saml-attribute-mapping-quota_mapping" is set to "urn:oid:1.3.6.1.4.1.49213.1.1.2"
+    And The setting "saml-attribute-mapping-group_mapping" is set to "groups"
     When I send a GET request to "http://localhost:8080/index.php/login"
     Then I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
     And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
@@ -89,7 +91,11 @@ Feature: Shibboleth
     And I should be redirected to "http://localhost:8080/index.php/apps/dashboard/"
     And The user value "id" should be "student1"
     And The user value "email" should be "student1@idptestbed.edu"
+    And The user value "quota.total" should be "209715200"
     And The user value "display-name" should be "Stud Ent"
+    And The user value "groups" should be "Students, Astrophysics"
+    And the group "SAML_Astrophysics" should exists
+    And the group "SAML_Students" should exists
     And The last login timestamp of "student1" should not be empty
 
   Scenario: Authenticating using Shibboleth with SAML with custom redirect URL

--- a/tests/integration/features/Shibboleth.feature
+++ b/tests/integration/features/Shibboleth.feature
@@ -122,3 +122,298 @@ Feature: Shibboleth
     And The user value "email" should be "student1@idptestbed.edu"
     And The user value "display-name" should be "Stud Ent"
     And The last login timestamp of "student1" should not be empty
+
+  Scenario: Migrating a local group to SAML backend while assigning a SAML user to it
+    Given The setting "type" is set to "saml"
+    And The setting "general-uid_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.1"
+    And The setting "idp-entityId" is set to "https://shibboleth-integration-nextcloud.localdomain/idp/shibboleth"
+    And The setting "idp-singleSignOnService.url" is set to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And The setting "idp-singleLogoutService.url" is set to "https://localhost:4443/idp/profile/Logout"
+    And The setting "idp-x509cert" is set to "MIIDnTCCAoWgAwIBAgIUGPx9uPjCu7c172IUgV84Tm94pBcwDQYJKoZIhvcNAQEL BQAwNzE1MDMGA1UEAwwsc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQu bG9jYWxkb21haW4wHhcNMTcwMTA0MTAxMTI3WhcNMzcwMTA0MTAxMTI3WjA3MTUw MwYDVQQDDCxzaGliYm9sZXRoLWludGVncmF0aW9uLW5leHRjbG91ZC5sb2NhbGRv bWFpbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKH+bPu45tk8/JRk XOxkyfbxocWZlY4mRumEUxscd3fn0oVzOrdWbHH7lCZV4bus4KxvJljc0Nm2K+Zr LoiRUUnf/LQ4LlehWVm5Kbc4kRgOXS0iGZN3SslAWPKyIg0tywg+TLOBPoS6EtST 1WuYg1JPMFxPfeFDWQ0dQYPlXIJWBFh6F2JMTb0FLECqA5l/ryYE13QisX5l+Mqo 6y3Dh7qIgaH0IJNobXoAcEWza7Kb2RnfhZRh9e0qjZIwBqTJUFM/6I86RYXn829s INUvYQQbez6VkGTdUQJ/GuXb/dD5sMQfOyK8hrRY5MozOmK32cz3JaAzSXpiSRS9 NxFwvicCAwEAAaOBoDCBnTAdBgNVHQ4EFgQUKn8+TV0WXSDeavvF0M8mWn1o8ukw fAYDVR0RBHUwc4Isc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQubG9j YWxkb21haW6GQ2h0dHBzOi8vc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xv dWQubG9jYWxkb21haW4vaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEB ABI6uzoIeLZT9Az2KTlLxIc6jZ4MDmhaVja4ZuBxTXEb7BFLfeASEJmQm1wgIMOn pJId3Kh3njW+3tOBWKm7lj8JxVVpAu4yMFSoQGPaVUgYB1AVm+pmAyPLzfJ/XGhf esCU2F/b0eHWcaIb3x+BZFX089Cd/PBtP84MNXdo+TccibxC8N39sr45qJM/7SC7 TfDYU0L4q2WZHJr4S7+0F+F4KaxLx9NzCvN4h6XaoWofZWir2iHO4NzbrVQGC0ei QybS/neBfni4A2g1lyzCb6xFB58JBvNCn7AAnDJULOE7S5XWUKsDAQVQrxTNkUq7 pnhlCQqZDwUdgmIXd1KB1So="
+    And The setting "security-authnRequestsSigned" is set to "1"
+    And The setting "security-wantAssertionsEncrypted" is set to "1"
+    And The setting "sp-x509cert" is set to "-----BEGIN CERTIFICATE-----MIIC+zCCAeOgAwIBAgIJAIgZuvWDBIrdMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xNzAxMDQxMTM5MjFaFw0yNzAxMDIxMTM5MjFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN3ESWaDH1JiJTy9yRJQV7kahPOxgBkIH2xwcYDL1k9deKNhSKLx7aGfxE244+HBcC6WLHKVUnOm0ld2qxQ4bMYiJXzZuqL67r07L5wxGAssv12lO92qohGmlHy3+VzRYUBmovu6upqOv3R2F8HBbo7Jc7Hvt7hOEJn/jPuFuF/fHit3mqU8l6IkrIZjpaW8T9fIWOXRq98U4+hkgWpqEZWsqlfE8BxAs9DeIMZab0GxO9stHLp+GYKx10uE4ezFcaDS8W+g2C8enCTt1HXGvcnj4o5zkC1lITGvcFTsiFqfIWyXeSufcxdc0W7HoG6J3ks0WJyK38sfFn0t2Ao6kX0CAwEAAaNQME4wHQYDVR0OBBYEFAoJzX6TVYAwC1GSPe6nObBG54zaMB8GA1UdIwQYMBaAFAoJzX6TVYAwC1GSPe6nObBG54zaMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJia9R70uXdUZtgujUPjLas4+sVajzlBFmqhBqpLAo934vljf9HISsHrPtdBcbS0d0rucqXwabDf0MlR18ksnT/NYpsTwMbMx76CrXi4zYEEW5lISKEO65aIkzVTcqKWSuhjtSnRdB6iOLsFiKmNMWXaIKMR5T0+AbR9wdQgn08W+3EEeHGvafVQfE3STVsSgNb1ft7DvcSUnfPXGU7KzvmTpZa0Hfmc7uY4vpdEEhLAdRhgLReS7USZskov7ooiPSoD+JRFi2gM4klBxTemHdNUa9oFnHMXuYKOkLbkgFvHxyy+QlLq2ELQTga5e7I83ZyOfGctyf8Ul6vGw10vbQ=-----END CERTIFICATE-----"
+    And The setting "sp-privateKey" is set to "-----BEGIN RSA PRIVATE KEY-----MIIEpAIBAAKCAQEA3cRJZoMfUmIlPL3JElBXuRqE87GAGQgfbHBxgMvWT114o2FIovHtoZ/ETbjj4cFwLpYscpVSc6bSV3arFDhsxiIlfNm6ovruvTsvnDEYCyy/XaU73aqiEaaUfLf5XNFhQGai+7q6mo6/dHYXwcFujslzse+3uE4Qmf+M+4W4X98eK3eapTyXoiSshmOlpbxP18hY5dGr3xTj6GSBamoRlayqV8TwHECz0N4gxlpvQbE72y0cun4ZgrHXS4Th7MVxoNLxb6DYLx6cJO3Udca9yePijnOQLWUhMa9wVOyIWp8hbJd5K59zF1zRbsegboneSzRYnIrfyx8WfS3YCjqRfQIDAQABAoIBAQC5CQAdcqZ9vLpJNilBCJxJLCFmm+HAAREHD8MErg9A5UK1P4S1wJp/0qieGPi68wXBOTgY2xKSwMycgb04/+NyZidVRu388takOW/+KNBg8pMxdZ6/05GqnI0kivSbR3CXpYuz8hekwhpo9+fWmKjApsHL47ItK6WaeKmPbAFsq1YJGzfp/DXg7LIvh9GA3C1LWWGV7SuCGOyX/2Moi8xRa7qBtH4hDo/0NRhTx7zjYjlBgNEr330pJUopc3+AtHE40R+xMr2zkGvq9RsCZxYxD2VWbLwQW0yNjWmQ2OTuMgJJvk2+N73QLHcB+tea82ZTszsNzRS9DLtc6qbsKEPZAoGBAO78U3vEuRyY56f/1hpo0xuCDwOkWGzgBQWkjJl6dlyVz/zKkhXBHpEYImyt8XRN0W3iGZYpZ2hCFJGTcDp32R6UiEyGLz0Uc8R/tva/TiRVW1FdNczzSHcB24b9OMK4vE9JLs8mA8Rp8YBgtLr5DDuMfYt/a/rZJbg/HIfIN98nAoGBAO2OInCX93t2I6zzRPIqKtI6q6FYNp64VIQjvw9Y8l0x3IdJZRP9H5C8ZhCeYPsgEqTXcXa4j5hL4rQzoUtxfxflBUUH60bcnd4LGaTCMYLS14G011E3GZlIP0sJi5OjEhy8fq3zt6jVzS9V/lPHB8i+w1D7CbPrMpW7B3k32vC7AoGAX/HvdkYhZyjAAEOG6m1hK68IZhbp5TP+8CgCxm9S65K9wKh3A8LXibrdvzIKOP4w8WOPkCipOkMlTNibeu24vj01hztr5aK7Y40+oEtnjNCz67N3MQQO+LBHOSeaTRqrh01DPKjvZECAU2D/zfzEe3fIw2Nxr3DUYub7hkvMmosCgYAzxbVVypjiLGYsDDyrdmsstCKxoDMPNmcdAVljc+QmUXaZeXJw/8qAVb78wjeqo1vM1zNgR2rsKyW2VkZB1fN39q7GU6qAIBa7zLmDAduegmr7VrlSduq6UFeS9/qWa4TIBICrUqFlR2tXdKtgANF+e6y/mmaL8qdsoH1JetXZfwKBgQC1vscRpdAXivjOOZAh+mzJWzS4BUl4CTJLYYIuOEXikmN5g0EdV2fhUEdkewmyKnXHsd0x83167bYgpTDNs71jUxDHy5NXlg2qIjLkf09X9wr19gBzDApfWzfh3vUqttyMZuQMLVNepGCWM2vjlY9KGl5OvZqY6d+7yO0mLV9GmQ==-----END RSA PRIVATE KEY-----"
+    And The setting "security-wantAssertionsSigned" is set to "1"
+    And The setting "localGroupsCheckForMigration" is set to '{\"dropAfter\":9223372036854775807,\"groups\":[\"Astrophysics\",\"Students\"]}'
+    And the local group "Astrophysics" is created
+    # Initial login so the user is known and belonging to SAML, directly followed by a logout
+    And I send a GET request to "http://localhost:8080/index.php/login"
+    And I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And I send a GET request with requesttoken to "http://localhost:8080/index.php/apps/user_saml/saml/sls"
+    # Set the proper attributes
+    And The setting "saml-attribute-mapping-email_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.3"
+    And The setting "saml-attribute-mapping-displayName_mapping" is set to "urn:oid:2.5.4.42 urn:oid:2.5.4.4"
+    And The setting "saml-attribute-mapping-group_mapping" is set to "groups"
+    And the cookies are cleared
+    # Now login in for good
+    When I send a GET request to "http://localhost:8080/index.php/login"
+    Then I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    #And I should be redirected to "http://localhost:8080/index.php/apps/dashboard/"
+    And The user value "groups" should be "Astrophysics,SAML_Students"
+    And the group backend of "Astrophysics" should be "Database"
+    And Then the group backend of "Astrophysics" must not be "user_saml"
+    When I execute the background job for class "OCA\\User_SAML\\Jobs\\MigrateGroups"
+    Then the group backend of "Astrophysics" should be "user_saml"
+    And Then the group backend of "Astrophysics" must not be "Database"
+    And The user value "groups" should be "Astrophysics,SAML_Students"
+
+  Scenario: Keeping the local admin group assigned to the SAML user
+    Given The setting "type" is set to "saml"
+    And The setting "general-uid_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.1"
+    And The setting "idp-entityId" is set to "https://shibboleth-integration-nextcloud.localdomain/idp/shibboleth"
+    And The setting "idp-singleSignOnService.url" is set to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And The setting "idp-singleLogoutService.url" is set to "https://localhost:4443/idp/profile/Logout"
+    And The setting "idp-x509cert" is set to "MIIDnTCCAoWgAwIBAgIUGPx9uPjCu7c172IUgV84Tm94pBcwDQYJKoZIhvcNAQEL BQAwNzE1MDMGA1UEAwwsc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQu bG9jYWxkb21haW4wHhcNMTcwMTA0MTAxMTI3WhcNMzcwMTA0MTAxMTI3WjA3MTUw MwYDVQQDDCxzaGliYm9sZXRoLWludGVncmF0aW9uLW5leHRjbG91ZC5sb2NhbGRv bWFpbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKH+bPu45tk8/JRk XOxkyfbxocWZlY4mRumEUxscd3fn0oVzOrdWbHH7lCZV4bus4KxvJljc0Nm2K+Zr LoiRUUnf/LQ4LlehWVm5Kbc4kRgOXS0iGZN3SslAWPKyIg0tywg+TLOBPoS6EtST 1WuYg1JPMFxPfeFDWQ0dQYPlXIJWBFh6F2JMTb0FLECqA5l/ryYE13QisX5l+Mqo 6y3Dh7qIgaH0IJNobXoAcEWza7Kb2RnfhZRh9e0qjZIwBqTJUFM/6I86RYXn829s INUvYQQbez6VkGTdUQJ/GuXb/dD5sMQfOyK8hrRY5MozOmK32cz3JaAzSXpiSRS9 NxFwvicCAwEAAaOBoDCBnTAdBgNVHQ4EFgQUKn8+TV0WXSDeavvF0M8mWn1o8ukw fAYDVR0RBHUwc4Isc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQubG9j YWxkb21haW6GQ2h0dHBzOi8vc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xv dWQubG9jYWxkb21haW4vaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEB ABI6uzoIeLZT9Az2KTlLxIc6jZ4MDmhaVja4ZuBxTXEb7BFLfeASEJmQm1wgIMOn pJId3Kh3njW+3tOBWKm7lj8JxVVpAu4yMFSoQGPaVUgYB1AVm+pmAyPLzfJ/XGhf esCU2F/b0eHWcaIb3x+BZFX089Cd/PBtP84MNXdo+TccibxC8N39sr45qJM/7SC7 TfDYU0L4q2WZHJr4S7+0F+F4KaxLx9NzCvN4h6XaoWofZWir2iHO4NzbrVQGC0ei QybS/neBfni4A2g1lyzCb6xFB58JBvNCn7AAnDJULOE7S5XWUKsDAQVQrxTNkUq7 pnhlCQqZDwUdgmIXd1KB1So="
+    And The setting "security-authnRequestsSigned" is set to "1"
+    And The setting "security-wantAssertionsEncrypted" is set to "1"
+    And The setting "sp-x509cert" is set to "-----BEGIN CERTIFICATE-----MIIC+zCCAeOgAwIBAgIJAIgZuvWDBIrdMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xNzAxMDQxMTM5MjFaFw0yNzAxMDIxMTM5MjFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN3ESWaDH1JiJTy9yRJQV7kahPOxgBkIH2xwcYDL1k9deKNhSKLx7aGfxE244+HBcC6WLHKVUnOm0ld2qxQ4bMYiJXzZuqL67r07L5wxGAssv12lO92qohGmlHy3+VzRYUBmovu6upqOv3R2F8HBbo7Jc7Hvt7hOEJn/jPuFuF/fHit3mqU8l6IkrIZjpaW8T9fIWOXRq98U4+hkgWpqEZWsqlfE8BxAs9DeIMZab0GxO9stHLp+GYKx10uE4ezFcaDS8W+g2C8enCTt1HXGvcnj4o5zkC1lITGvcFTsiFqfIWyXeSufcxdc0W7HoG6J3ks0WJyK38sfFn0t2Ao6kX0CAwEAAaNQME4wHQYDVR0OBBYEFAoJzX6TVYAwC1GSPe6nObBG54zaMB8GA1UdIwQYMBaAFAoJzX6TVYAwC1GSPe6nObBG54zaMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJia9R70uXdUZtgujUPjLas4+sVajzlBFmqhBqpLAo934vljf9HISsHrPtdBcbS0d0rucqXwabDf0MlR18ksnT/NYpsTwMbMx76CrXi4zYEEW5lISKEO65aIkzVTcqKWSuhjtSnRdB6iOLsFiKmNMWXaIKMR5T0+AbR9wdQgn08W+3EEeHGvafVQfE3STVsSgNb1ft7DvcSUnfPXGU7KzvmTpZa0Hfmc7uY4vpdEEhLAdRhgLReS7USZskov7ooiPSoD+JRFi2gM4klBxTemHdNUa9oFnHMXuYKOkLbkgFvHxyy+QlLq2ELQTga5e7I83ZyOfGctyf8Ul6vGw10vbQ=-----END CERTIFICATE-----"
+    And The setting "sp-privateKey" is set to "-----BEGIN RSA PRIVATE KEY-----MIIEpAIBAAKCAQEA3cRJZoMfUmIlPL3JElBXuRqE87GAGQgfbHBxgMvWT114o2FIovHtoZ/ETbjj4cFwLpYscpVSc6bSV3arFDhsxiIlfNm6ovruvTsvnDEYCyy/XaU73aqiEaaUfLf5XNFhQGai+7q6mo6/dHYXwcFujslzse+3uE4Qmf+M+4W4X98eK3eapTyXoiSshmOlpbxP18hY5dGr3xTj6GSBamoRlayqV8TwHECz0N4gxlpvQbE72y0cun4ZgrHXS4Th7MVxoNLxb6DYLx6cJO3Udca9yePijnOQLWUhMa9wVOyIWp8hbJd5K59zF1zRbsegboneSzRYnIrfyx8WfS3YCjqRfQIDAQABAoIBAQC5CQAdcqZ9vLpJNilBCJxJLCFmm+HAAREHD8MErg9A5UK1P4S1wJp/0qieGPi68wXBOTgY2xKSwMycgb04/+NyZidVRu388takOW/+KNBg8pMxdZ6/05GqnI0kivSbR3CXpYuz8hekwhpo9+fWmKjApsHL47ItK6WaeKmPbAFsq1YJGzfp/DXg7LIvh9GA3C1LWWGV7SuCGOyX/2Moi8xRa7qBtH4hDo/0NRhTx7zjYjlBgNEr330pJUopc3+AtHE40R+xMr2zkGvq9RsCZxYxD2VWbLwQW0yNjWmQ2OTuMgJJvk2+N73QLHcB+tea82ZTszsNzRS9DLtc6qbsKEPZAoGBAO78U3vEuRyY56f/1hpo0xuCDwOkWGzgBQWkjJl6dlyVz/zKkhXBHpEYImyt8XRN0W3iGZYpZ2hCFJGTcDp32R6UiEyGLz0Uc8R/tva/TiRVW1FdNczzSHcB24b9OMK4vE9JLs8mA8Rp8YBgtLr5DDuMfYt/a/rZJbg/HIfIN98nAoGBAO2OInCX93t2I6zzRPIqKtI6q6FYNp64VIQjvw9Y8l0x3IdJZRP9H5C8ZhCeYPsgEqTXcXa4j5hL4rQzoUtxfxflBUUH60bcnd4LGaTCMYLS14G011E3GZlIP0sJi5OjEhy8fq3zt6jVzS9V/lPHB8i+w1D7CbPrMpW7B3k32vC7AoGAX/HvdkYhZyjAAEOG6m1hK68IZhbp5TP+8CgCxm9S65K9wKh3A8LXibrdvzIKOP4w8WOPkCipOkMlTNibeu24vj01hztr5aK7Y40+oEtnjNCz67N3MQQO+LBHOSeaTRqrh01DPKjvZECAU2D/zfzEe3fIw2Nxr3DUYub7hkvMmosCgYAzxbVVypjiLGYsDDyrdmsstCKxoDMPNmcdAVljc+QmUXaZeXJw/8qAVb78wjeqo1vM1zNgR2rsKyW2VkZB1fN39q7GU6qAIBa7zLmDAduegmr7VrlSduq6UFeS9/qWa4TIBICrUqFlR2tXdKtgANF+e6y/mmaL8qdsoH1JetXZfwKBgQC1vscRpdAXivjOOZAh+mzJWzS4BUl4CTJLYYIuOEXikmN5g0EdV2fhUEdkewmyKnXHsd0x83167bYgpTDNs71jUxDHy5NXlg2qIjLkf09X9wr19gBzDApfWzfh3vUqttyMZuQMLVNepGCWM2vjlY9KGl5OvZqY6d+7yO0mLV9GmQ==-----END RSA PRIVATE KEY-----"
+    And The setting "security-wantAssertionsSigned" is set to "1"
+    And The setting "localGroupsCheckForMigration" is set to '{\"dropAfter\":9223372036854775807,\"groups\":[\"Astrophysics\",\"Students\"]}'
+    # Initial login so the user is known and belonging to SAML, directly followed by a logout
+    And I send a GET request to "http://localhost:8080/index.php/login"
+    And I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And I send a GET request with requesttoken to "http://localhost:8080/index.php/apps/user_saml/saml/sls"
+    And the user "student1" is added to the group "admin"
+    # Set the proper attributes
+    And The setting "saml-attribute-mapping-email_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.3"
+    And The setting "saml-attribute-mapping-displayName_mapping" is set to "urn:oid:2.5.4.42 urn:oid:2.5.4.4"
+    And The setting "saml-attribute-mapping-group_mapping" is set to "groups"
+    And the cookies are cleared
+    # Now login in for good
+    When I send a GET request to "http://localhost:8080/index.php/login"
+    Then I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And The user value "groups" should be "admin,SAML_Astrophysics,SAML_Students"
+    When I execute the background job for class "OCA\\User_SAML\\Jobs\\MigrateGroups"
+    Then the group backend of "admin" should be "Database"
+    And Then the group backend of "admin" must not be "user_saml"
+    And The user value "groups" should be "admin,SAML_Astrophysics,SAML_Students"
+
+  Scenario: Not migrating a group with only SAML members when not in migration mode anymore
+    Given The setting "type" is set to "saml"
+    And The setting "general-uid_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.1"
+    And The setting "idp-entityId" is set to "https://shibboleth-integration-nextcloud.localdomain/idp/shibboleth"
+    And The setting "idp-singleSignOnService.url" is set to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And The setting "idp-singleLogoutService.url" is set to "https://localhost:4443/idp/profile/Logout"
+    And The setting "idp-x509cert" is set to "MIIDnTCCAoWgAwIBAgIUGPx9uPjCu7c172IUgV84Tm94pBcwDQYJKoZIhvcNAQEL BQAwNzE1MDMGA1UEAwwsc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQu bG9jYWxkb21haW4wHhcNMTcwMTA0MTAxMTI3WhcNMzcwMTA0MTAxMTI3WjA3MTUw MwYDVQQDDCxzaGliYm9sZXRoLWludGVncmF0aW9uLW5leHRjbG91ZC5sb2NhbGRv bWFpbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKH+bPu45tk8/JRk XOxkyfbxocWZlY4mRumEUxscd3fn0oVzOrdWbHH7lCZV4bus4KxvJljc0Nm2K+Zr LoiRUUnf/LQ4LlehWVm5Kbc4kRgOXS0iGZN3SslAWPKyIg0tywg+TLOBPoS6EtST 1WuYg1JPMFxPfeFDWQ0dQYPlXIJWBFh6F2JMTb0FLECqA5l/ryYE13QisX5l+Mqo 6y3Dh7qIgaH0IJNobXoAcEWza7Kb2RnfhZRh9e0qjZIwBqTJUFM/6I86RYXn829s INUvYQQbez6VkGTdUQJ/GuXb/dD5sMQfOyK8hrRY5MozOmK32cz3JaAzSXpiSRS9 NxFwvicCAwEAAaOBoDCBnTAdBgNVHQ4EFgQUKn8+TV0WXSDeavvF0M8mWn1o8ukw fAYDVR0RBHUwc4Isc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQubG9j YWxkb21haW6GQ2h0dHBzOi8vc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xv dWQubG9jYWxkb21haW4vaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEB ABI6uzoIeLZT9Az2KTlLxIc6jZ4MDmhaVja4ZuBxTXEb7BFLfeASEJmQm1wgIMOn pJId3Kh3njW+3tOBWKm7lj8JxVVpAu4yMFSoQGPaVUgYB1AVm+pmAyPLzfJ/XGhf esCU2F/b0eHWcaIb3x+BZFX089Cd/PBtP84MNXdo+TccibxC8N39sr45qJM/7SC7 TfDYU0L4q2WZHJr4S7+0F+F4KaxLx9NzCvN4h6XaoWofZWir2iHO4NzbrVQGC0ei QybS/neBfni4A2g1lyzCb6xFB58JBvNCn7AAnDJULOE7S5XWUKsDAQVQrxTNkUq7 pnhlCQqZDwUdgmIXd1KB1So="
+    And The setting "security-authnRequestsSigned" is set to "1"
+    And The setting "security-wantAssertionsEncrypted" is set to "1"
+    And The setting "sp-x509cert" is set to "-----BEGIN CERTIFICATE-----MIIC+zCCAeOgAwIBAgIJAIgZuvWDBIrdMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xNzAxMDQxMTM5MjFaFw0yNzAxMDIxMTM5MjFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN3ESWaDH1JiJTy9yRJQV7kahPOxgBkIH2xwcYDL1k9deKNhSKLx7aGfxE244+HBcC6WLHKVUnOm0ld2qxQ4bMYiJXzZuqL67r07L5wxGAssv12lO92qohGmlHy3+VzRYUBmovu6upqOv3R2F8HBbo7Jc7Hvt7hOEJn/jPuFuF/fHit3mqU8l6IkrIZjpaW8T9fIWOXRq98U4+hkgWpqEZWsqlfE8BxAs9DeIMZab0GxO9stHLp+GYKx10uE4ezFcaDS8W+g2C8enCTt1HXGvcnj4o5zkC1lITGvcFTsiFqfIWyXeSufcxdc0W7HoG6J3ks0WJyK38sfFn0t2Ao6kX0CAwEAAaNQME4wHQYDVR0OBBYEFAoJzX6TVYAwC1GSPe6nObBG54zaMB8GA1UdIwQYMBaAFAoJzX6TVYAwC1GSPe6nObBG54zaMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJia9R70uXdUZtgujUPjLas4+sVajzlBFmqhBqpLAo934vljf9HISsHrPtdBcbS0d0rucqXwabDf0MlR18ksnT/NYpsTwMbMx76CrXi4zYEEW5lISKEO65aIkzVTcqKWSuhjtSnRdB6iOLsFiKmNMWXaIKMR5T0+AbR9wdQgn08W+3EEeHGvafVQfE3STVsSgNb1ft7DvcSUnfPXGU7KzvmTpZa0Hfmc7uY4vpdEEhLAdRhgLReS7USZskov7ooiPSoD+JRFi2gM4klBxTemHdNUa9oFnHMXuYKOkLbkgFvHxyy+QlLq2ELQTga5e7I83ZyOfGctyf8Ul6vGw10vbQ=-----END CERTIFICATE-----"
+    And The setting "sp-privateKey" is set to "-----BEGIN RSA PRIVATE KEY-----MIIEpAIBAAKCAQEA3cRJZoMfUmIlPL3JElBXuRqE87GAGQgfbHBxgMvWT114o2FIovHtoZ/ETbjj4cFwLpYscpVSc6bSV3arFDhsxiIlfNm6ovruvTsvnDEYCyy/XaU73aqiEaaUfLf5XNFhQGai+7q6mo6/dHYXwcFujslzse+3uE4Qmf+M+4W4X98eK3eapTyXoiSshmOlpbxP18hY5dGr3xTj6GSBamoRlayqV8TwHECz0N4gxlpvQbE72y0cun4ZgrHXS4Th7MVxoNLxb6DYLx6cJO3Udca9yePijnOQLWUhMa9wVOyIWp8hbJd5K59zF1zRbsegboneSzRYnIrfyx8WfS3YCjqRfQIDAQABAoIBAQC5CQAdcqZ9vLpJNilBCJxJLCFmm+HAAREHD8MErg9A5UK1P4S1wJp/0qieGPi68wXBOTgY2xKSwMycgb04/+NyZidVRu388takOW/+KNBg8pMxdZ6/05GqnI0kivSbR3CXpYuz8hekwhpo9+fWmKjApsHL47ItK6WaeKmPbAFsq1YJGzfp/DXg7LIvh9GA3C1LWWGV7SuCGOyX/2Moi8xRa7qBtH4hDo/0NRhTx7zjYjlBgNEr330pJUopc3+AtHE40R+xMr2zkGvq9RsCZxYxD2VWbLwQW0yNjWmQ2OTuMgJJvk2+N73QLHcB+tea82ZTszsNzRS9DLtc6qbsKEPZAoGBAO78U3vEuRyY56f/1hpo0xuCDwOkWGzgBQWkjJl6dlyVz/zKkhXBHpEYImyt8XRN0W3iGZYpZ2hCFJGTcDp32R6UiEyGLz0Uc8R/tva/TiRVW1FdNczzSHcB24b9OMK4vE9JLs8mA8Rp8YBgtLr5DDuMfYt/a/rZJbg/HIfIN98nAoGBAO2OInCX93t2I6zzRPIqKtI6q6FYNp64VIQjvw9Y8l0x3IdJZRP9H5C8ZhCeYPsgEqTXcXa4j5hL4rQzoUtxfxflBUUH60bcnd4LGaTCMYLS14G011E3GZlIP0sJi5OjEhy8fq3zt6jVzS9V/lPHB8i+w1D7CbPrMpW7B3k32vC7AoGAX/HvdkYhZyjAAEOG6m1hK68IZhbp5TP+8CgCxm9S65K9wKh3A8LXibrdvzIKOP4w8WOPkCipOkMlTNibeu24vj01hztr5aK7Y40+oEtnjNCz67N3MQQO+LBHOSeaTRqrh01DPKjvZECAU2D/zfzEe3fIw2Nxr3DUYub7hkvMmosCgYAzxbVVypjiLGYsDDyrdmsstCKxoDMPNmcdAVljc+QmUXaZeXJw/8qAVb78wjeqo1vM1zNgR2rsKyW2VkZB1fN39q7GU6qAIBa7zLmDAduegmr7VrlSduq6UFeS9/qWa4TIBICrUqFlR2tXdKtgANF+e6y/mmaL8qdsoH1JetXZfwKBgQC1vscRpdAXivjOOZAh+mzJWzS4BUl4CTJLYYIuOEXikmN5g0EdV2fhUEdkewmyKnXHsd0x83167bYgpTDNs71jUxDHy5NXlg2qIjLkf09X9wr19gBzDApfWzfh3vUqttyMZuQMLVNepGCWM2vjlY9KGl5OvZqY6d+7yO0mLV9GmQ==-----END RSA PRIVATE KEY-----"
+    And The setting "security-wantAssertionsSigned" is set to "1"
+    And the local group "Astrophysics" is created
+    # Initial login so the user is known and belonging to SAML, directly followed by a logout
+    And I send a GET request to "http://localhost:8080/index.php/login"
+    And I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And I send a GET request with requesttoken to "http://localhost:8080/index.php/apps/user_saml/saml/sls"
+    And the user "student1" is added to the group "Astrophysics"
+    # Set the proper attributes
+    And The setting "saml-attribute-mapping-email_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.3"
+    And The setting "saml-attribute-mapping-displayName_mapping" is set to "urn:oid:2.5.4.42 urn:oid:2.5.4.4"
+    And The setting "saml-attribute-mapping-group_mapping" is set to "groups"
+    And the cookies are cleared
+    # Now login in for good
+    When I send a GET request to "http://localhost:8080/index.php/login"
+    Then I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And The user value "groups" should be "Astrophysics,SAML_Astrophysics,SAML_Students"
+    And I expect no background job for class "OCA\\User_SAML\\Jobs\\MigrateGroups"
+    Then the group backend of "Astrophysics" should be "Database"
+    And Then the group backend of "Astrophysics" must not be "user_saml"
+    And The user value "groups" should be "Astrophysics,SAML_Astrophysics,SAML_Students"
+
+  Scenario: Keeping a group with members of mixed backends local
+    Given The setting "type" is set to "saml"
+    And The setting "general-uid_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.1"
+    And The setting "idp-entityId" is set to "https://shibboleth-integration-nextcloud.localdomain/idp/shibboleth"
+    And The setting "idp-singleSignOnService.url" is set to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And The setting "idp-singleLogoutService.url" is set to "https://localhost:4443/idp/profile/Logout"
+    And The setting "idp-x509cert" is set to "MIIDnTCCAoWgAwIBAgIUGPx9uPjCu7c172IUgV84Tm94pBcwDQYJKoZIhvcNAQEL BQAwNzE1MDMGA1UEAwwsc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQu bG9jYWxkb21haW4wHhcNMTcwMTA0MTAxMTI3WhcNMzcwMTA0MTAxMTI3WjA3MTUw MwYDVQQDDCxzaGliYm9sZXRoLWludGVncmF0aW9uLW5leHRjbG91ZC5sb2NhbGRv bWFpbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKH+bPu45tk8/JRk XOxkyfbxocWZlY4mRumEUxscd3fn0oVzOrdWbHH7lCZV4bus4KxvJljc0Nm2K+Zr LoiRUUnf/LQ4LlehWVm5Kbc4kRgOXS0iGZN3SslAWPKyIg0tywg+TLOBPoS6EtST 1WuYg1JPMFxPfeFDWQ0dQYPlXIJWBFh6F2JMTb0FLECqA5l/ryYE13QisX5l+Mqo 6y3Dh7qIgaH0IJNobXoAcEWza7Kb2RnfhZRh9e0qjZIwBqTJUFM/6I86RYXn829s INUvYQQbez6VkGTdUQJ/GuXb/dD5sMQfOyK8hrRY5MozOmK32cz3JaAzSXpiSRS9 NxFwvicCAwEAAaOBoDCBnTAdBgNVHQ4EFgQUKn8+TV0WXSDeavvF0M8mWn1o8ukw fAYDVR0RBHUwc4Isc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQubG9j YWxkb21haW6GQ2h0dHBzOi8vc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xv dWQubG9jYWxkb21haW4vaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEB ABI6uzoIeLZT9Az2KTlLxIc6jZ4MDmhaVja4ZuBxTXEb7BFLfeASEJmQm1wgIMOn pJId3Kh3njW+3tOBWKm7lj8JxVVpAu4yMFSoQGPaVUgYB1AVm+pmAyPLzfJ/XGhf esCU2F/b0eHWcaIb3x+BZFX089Cd/PBtP84MNXdo+TccibxC8N39sr45qJM/7SC7 TfDYU0L4q2WZHJr4S7+0F+F4KaxLx9NzCvN4h6XaoWofZWir2iHO4NzbrVQGC0ei QybS/neBfni4A2g1lyzCb6xFB58JBvNCn7AAnDJULOE7S5XWUKsDAQVQrxTNkUq7 pnhlCQqZDwUdgmIXd1KB1So="
+    And The setting "security-authnRequestsSigned" is set to "1"
+    And The setting "security-wantAssertionsEncrypted" is set to "1"
+    And The setting "sp-x509cert" is set to "-----BEGIN CERTIFICATE-----MIIC+zCCAeOgAwIBAgIJAIgZuvWDBIrdMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xNzAxMDQxMTM5MjFaFw0yNzAxMDIxMTM5MjFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN3ESWaDH1JiJTy9yRJQV7kahPOxgBkIH2xwcYDL1k9deKNhSKLx7aGfxE244+HBcC6WLHKVUnOm0ld2qxQ4bMYiJXzZuqL67r07L5wxGAssv12lO92qohGmlHy3+VzRYUBmovu6upqOv3R2F8HBbo7Jc7Hvt7hOEJn/jPuFuF/fHit3mqU8l6IkrIZjpaW8T9fIWOXRq98U4+hkgWpqEZWsqlfE8BxAs9DeIMZab0GxO9stHLp+GYKx10uE4ezFcaDS8W+g2C8enCTt1HXGvcnj4o5zkC1lITGvcFTsiFqfIWyXeSufcxdc0W7HoG6J3ks0WJyK38sfFn0t2Ao6kX0CAwEAAaNQME4wHQYDVR0OBBYEFAoJzX6TVYAwC1GSPe6nObBG54zaMB8GA1UdIwQYMBaAFAoJzX6TVYAwC1GSPe6nObBG54zaMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJia9R70uXdUZtgujUPjLas4+sVajzlBFmqhBqpLAo934vljf9HISsHrPtdBcbS0d0rucqXwabDf0MlR18ksnT/NYpsTwMbMx76CrXi4zYEEW5lISKEO65aIkzVTcqKWSuhjtSnRdB6iOLsFiKmNMWXaIKMR5T0+AbR9wdQgn08W+3EEeHGvafVQfE3STVsSgNb1ft7DvcSUnfPXGU7KzvmTpZa0Hfmc7uY4vpdEEhLAdRhgLReS7USZskov7ooiPSoD+JRFi2gM4klBxTemHdNUa9oFnHMXuYKOkLbkgFvHxyy+QlLq2ELQTga5e7I83ZyOfGctyf8Ul6vGw10vbQ=-----END CERTIFICATE-----"
+    And The setting "sp-privateKey" is set to "-----BEGIN RSA PRIVATE KEY-----MIIEpAIBAAKCAQEA3cRJZoMfUmIlPL3JElBXuRqE87GAGQgfbHBxgMvWT114o2FIovHtoZ/ETbjj4cFwLpYscpVSc6bSV3arFDhsxiIlfNm6ovruvTsvnDEYCyy/XaU73aqiEaaUfLf5XNFhQGai+7q6mo6/dHYXwcFujslzse+3uE4Qmf+M+4W4X98eK3eapTyXoiSshmOlpbxP18hY5dGr3xTj6GSBamoRlayqV8TwHECz0N4gxlpvQbE72y0cun4ZgrHXS4Th7MVxoNLxb6DYLx6cJO3Udca9yePijnOQLWUhMa9wVOyIWp8hbJd5K59zF1zRbsegboneSzRYnIrfyx8WfS3YCjqRfQIDAQABAoIBAQC5CQAdcqZ9vLpJNilBCJxJLCFmm+HAAREHD8MErg9A5UK1P4S1wJp/0qieGPi68wXBOTgY2xKSwMycgb04/+NyZidVRu388takOW/+KNBg8pMxdZ6/05GqnI0kivSbR3CXpYuz8hekwhpo9+fWmKjApsHL47ItK6WaeKmPbAFsq1YJGzfp/DXg7LIvh9GA3C1LWWGV7SuCGOyX/2Moi8xRa7qBtH4hDo/0NRhTx7zjYjlBgNEr330pJUopc3+AtHE40R+xMr2zkGvq9RsCZxYxD2VWbLwQW0yNjWmQ2OTuMgJJvk2+N73QLHcB+tea82ZTszsNzRS9DLtc6qbsKEPZAoGBAO78U3vEuRyY56f/1hpo0xuCDwOkWGzgBQWkjJl6dlyVz/zKkhXBHpEYImyt8XRN0W3iGZYpZ2hCFJGTcDp32R6UiEyGLz0Uc8R/tva/TiRVW1FdNczzSHcB24b9OMK4vE9JLs8mA8Rp8YBgtLr5DDuMfYt/a/rZJbg/HIfIN98nAoGBAO2OInCX93t2I6zzRPIqKtI6q6FYNp64VIQjvw9Y8l0x3IdJZRP9H5C8ZhCeYPsgEqTXcXa4j5hL4rQzoUtxfxflBUUH60bcnd4LGaTCMYLS14G011E3GZlIP0sJi5OjEhy8fq3zt6jVzS9V/lPHB8i+w1D7CbPrMpW7B3k32vC7AoGAX/HvdkYhZyjAAEOG6m1hK68IZhbp5TP+8CgCxm9S65K9wKh3A8LXibrdvzIKOP4w8WOPkCipOkMlTNibeu24vj01hztr5aK7Y40+oEtnjNCz67N3MQQO+LBHOSeaTRqrh01DPKjvZECAU2D/zfzEe3fIw2Nxr3DUYub7hkvMmosCgYAzxbVVypjiLGYsDDyrdmsstCKxoDMPNmcdAVljc+QmUXaZeXJw/8qAVb78wjeqo1vM1zNgR2rsKyW2VkZB1fN39q7GU6qAIBa7zLmDAduegmr7VrlSduq6UFeS9/qWa4TIBICrUqFlR2tXdKtgANF+e6y/mmaL8qdsoH1JetXZfwKBgQC1vscRpdAXivjOOZAh+mzJWzS4BUl4CTJLYYIuOEXikmN5g0EdV2fhUEdkewmyKnXHsd0x83167bYgpTDNs71jUxDHy5NXlg2qIjLkf09X9wr19gBzDApfWzfh3vUqttyMZuQMLVNepGCWM2vjlY9KGl5OvZqY6d+7yO0mLV9GmQ==-----END RSA PRIVATE KEY-----"
+    And The setting "security-wantAssertionsSigned" is set to "1"
+    And The setting "localGroupsCheckForMigration" is set to '{\"dropAfter\":9223372036854775807,\"groups\":[\"Astrophysics\",\"Students\", \"Mixed Bag Of Sweets\"]}'
+    # Initial login so the user is known and belonging to SAML, directly followed by a logout
+    And I send a GET request to "http://localhost:8080/index.php/login"
+    And I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And I send a GET request with requesttoken to "http://localhost:8080/index.php/apps/user_saml/saml/sls"
+    And A local user with uid "lochlan" exists
+    And the local group "Mixed Bag Of Sweets" is created
+    And the user "lochlan" is added to the group "Mixed Bag Of Sweets"
+    And the user "student1" is added to the group "Mixed Bag Of Sweets"
+    # Set the proper attributes
+    And The setting "saml-attribute-mapping-email_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.3"
+    And The setting "saml-attribute-mapping-displayName_mapping" is set to "urn:oid:2.5.4.42 urn:oid:2.5.4.4"
+    And The setting "saml-attribute-mapping-group_mapping" is set to "groups"
+    And the cookies are cleared
+    # Now login in for good
+    When I send a GET request to "http://localhost:8080/index.php/login"
+    Then I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And The user value "groups" should be "Mixed Bag Of Sweets,SAML_Astrophysics,SAML_Students"
+    When I execute the background job for class "OCA\\User_SAML\\Jobs\\MigrateGroups"
+    Then the group backend of "Mixed Bag Of Sweets" should be "Database"
+    And Then the group backend of "Mixed Bag Of Sweets" must not be "user_saml"
+    And The user value "groups" should be "Mixed Bag Of Sweets,SAML_Astrophysics,SAML_Students"
+
+  Scenario: Not migrating a group with only SAML members that is not in the migration list
+    Given The setting "type" is set to "saml"
+    And The setting "general-uid_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.1"
+    And The setting "idp-entityId" is set to "https://shibboleth-integration-nextcloud.localdomain/idp/shibboleth"
+    And The setting "idp-singleSignOnService.url" is set to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And The setting "idp-singleLogoutService.url" is set to "https://localhost:4443/idp/profile/Logout"
+    And The setting "idp-x509cert" is set to "MIIDnTCCAoWgAwIBAgIUGPx9uPjCu7c172IUgV84Tm94pBcwDQYJKoZIhvcNAQEL BQAwNzE1MDMGA1UEAwwsc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQu bG9jYWxkb21haW4wHhcNMTcwMTA0MTAxMTI3WhcNMzcwMTA0MTAxMTI3WjA3MTUw MwYDVQQDDCxzaGliYm9sZXRoLWludGVncmF0aW9uLW5leHRjbG91ZC5sb2NhbGRv bWFpbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKH+bPu45tk8/JRk XOxkyfbxocWZlY4mRumEUxscd3fn0oVzOrdWbHH7lCZV4bus4KxvJljc0Nm2K+Zr LoiRUUnf/LQ4LlehWVm5Kbc4kRgOXS0iGZN3SslAWPKyIg0tywg+TLOBPoS6EtST 1WuYg1JPMFxPfeFDWQ0dQYPlXIJWBFh6F2JMTb0FLECqA5l/ryYE13QisX5l+Mqo 6y3Dh7qIgaH0IJNobXoAcEWza7Kb2RnfhZRh9e0qjZIwBqTJUFM/6I86RYXn829s INUvYQQbez6VkGTdUQJ/GuXb/dD5sMQfOyK8hrRY5MozOmK32cz3JaAzSXpiSRS9 NxFwvicCAwEAAaOBoDCBnTAdBgNVHQ4EFgQUKn8+TV0WXSDeavvF0M8mWn1o8ukw fAYDVR0RBHUwc4Isc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQubG9j YWxkb21haW6GQ2h0dHBzOi8vc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xv dWQubG9jYWxkb21haW4vaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEB ABI6uzoIeLZT9Az2KTlLxIc6jZ4MDmhaVja4ZuBxTXEb7BFLfeASEJmQm1wgIMOn pJId3Kh3njW+3tOBWKm7lj8JxVVpAu4yMFSoQGPaVUgYB1AVm+pmAyPLzfJ/XGhf esCU2F/b0eHWcaIb3x+BZFX089Cd/PBtP84MNXdo+TccibxC8N39sr45qJM/7SC7 TfDYU0L4q2WZHJr4S7+0F+F4KaxLx9NzCvN4h6XaoWofZWir2iHO4NzbrVQGC0ei QybS/neBfni4A2g1lyzCb6xFB58JBvNCn7AAnDJULOE7S5XWUKsDAQVQrxTNkUq7 pnhlCQqZDwUdgmIXd1KB1So="
+    And The setting "security-authnRequestsSigned" is set to "1"
+    And The setting "security-wantAssertionsEncrypted" is set to "1"
+    And The setting "sp-x509cert" is set to "-----BEGIN CERTIFICATE-----MIIC+zCCAeOgAwIBAgIJAIgZuvWDBIrdMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xNzAxMDQxMTM5MjFaFw0yNzAxMDIxMTM5MjFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN3ESWaDH1JiJTy9yRJQV7kahPOxgBkIH2xwcYDL1k9deKNhSKLx7aGfxE244+HBcC6WLHKVUnOm0ld2qxQ4bMYiJXzZuqL67r07L5wxGAssv12lO92qohGmlHy3+VzRYUBmovu6upqOv3R2F8HBbo7Jc7Hvt7hOEJn/jPuFuF/fHit3mqU8l6IkrIZjpaW8T9fIWOXRq98U4+hkgWpqEZWsqlfE8BxAs9DeIMZab0GxO9stHLp+GYKx10uE4ezFcaDS8W+g2C8enCTt1HXGvcnj4o5zkC1lITGvcFTsiFqfIWyXeSufcxdc0W7HoG6J3ks0WJyK38sfFn0t2Ao6kX0CAwEAAaNQME4wHQYDVR0OBBYEFAoJzX6TVYAwC1GSPe6nObBG54zaMB8GA1UdIwQYMBaAFAoJzX6TVYAwC1GSPe6nObBG54zaMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJia9R70uXdUZtgujUPjLas4+sVajzlBFmqhBqpLAo934vljf9HISsHrPtdBcbS0d0rucqXwabDf0MlR18ksnT/NYpsTwMbMx76CrXi4zYEEW5lISKEO65aIkzVTcqKWSuhjtSnRdB6iOLsFiKmNMWXaIKMR5T0+AbR9wdQgn08W+3EEeHGvafVQfE3STVsSgNb1ft7DvcSUnfPXGU7KzvmTpZa0Hfmc7uY4vpdEEhLAdRhgLReS7USZskov7ooiPSoD+JRFi2gM4klBxTemHdNUa9oFnHMXuYKOkLbkgFvHxyy+QlLq2ELQTga5e7I83ZyOfGctyf8Ul6vGw10vbQ=-----END CERTIFICATE-----"
+    And The setting "sp-privateKey" is set to "-----BEGIN RSA PRIVATE KEY-----MIIEpAIBAAKCAQEA3cRJZoMfUmIlPL3JElBXuRqE87GAGQgfbHBxgMvWT114o2FIovHtoZ/ETbjj4cFwLpYscpVSc6bSV3arFDhsxiIlfNm6ovruvTsvnDEYCyy/XaU73aqiEaaUfLf5XNFhQGai+7q6mo6/dHYXwcFujslzse+3uE4Qmf+M+4W4X98eK3eapTyXoiSshmOlpbxP18hY5dGr3xTj6GSBamoRlayqV8TwHECz0N4gxlpvQbE72y0cun4ZgrHXS4Th7MVxoNLxb6DYLx6cJO3Udca9yePijnOQLWUhMa9wVOyIWp8hbJd5K59zF1zRbsegboneSzRYnIrfyx8WfS3YCjqRfQIDAQABAoIBAQC5CQAdcqZ9vLpJNilBCJxJLCFmm+HAAREHD8MErg9A5UK1P4S1wJp/0qieGPi68wXBOTgY2xKSwMycgb04/+NyZidVRu388takOW/+KNBg8pMxdZ6/05GqnI0kivSbR3CXpYuz8hekwhpo9+fWmKjApsHL47ItK6WaeKmPbAFsq1YJGzfp/DXg7LIvh9GA3C1LWWGV7SuCGOyX/2Moi8xRa7qBtH4hDo/0NRhTx7zjYjlBgNEr330pJUopc3+AtHE40R+xMr2zkGvq9RsCZxYxD2VWbLwQW0yNjWmQ2OTuMgJJvk2+N73QLHcB+tea82ZTszsNzRS9DLtc6qbsKEPZAoGBAO78U3vEuRyY56f/1hpo0xuCDwOkWGzgBQWkjJl6dlyVz/zKkhXBHpEYImyt8XRN0W3iGZYpZ2hCFJGTcDp32R6UiEyGLz0Uc8R/tva/TiRVW1FdNczzSHcB24b9OMK4vE9JLs8mA8Rp8YBgtLr5DDuMfYt/a/rZJbg/HIfIN98nAoGBAO2OInCX93t2I6zzRPIqKtI6q6FYNp64VIQjvw9Y8l0x3IdJZRP9H5C8ZhCeYPsgEqTXcXa4j5hL4rQzoUtxfxflBUUH60bcnd4LGaTCMYLS14G011E3GZlIP0sJi5OjEhy8fq3zt6jVzS9V/lPHB8i+w1D7CbPrMpW7B3k32vC7AoGAX/HvdkYhZyjAAEOG6m1hK68IZhbp5TP+8CgCxm9S65K9wKh3A8LXibrdvzIKOP4w8WOPkCipOkMlTNibeu24vj01hztr5aK7Y40+oEtnjNCz67N3MQQO+LBHOSeaTRqrh01DPKjvZECAU2D/zfzEe3fIw2Nxr3DUYub7hkvMmosCgYAzxbVVypjiLGYsDDyrdmsstCKxoDMPNmcdAVljc+QmUXaZeXJw/8qAVb78wjeqo1vM1zNgR2rsKyW2VkZB1fN39q7GU6qAIBa7zLmDAduegmr7VrlSduq6UFeS9/qWa4TIBICrUqFlR2tXdKtgANF+e6y/mmaL8qdsoH1JetXZfwKBgQC1vscRpdAXivjOOZAh+mzJWzS4BUl4CTJLYYIuOEXikmN5g0EdV2fhUEdkewmyKnXHsd0x83167bYgpTDNs71jUxDHy5NXlg2qIjLkf09X9wr19gBzDApfWzfh3vUqttyMZuQMLVNepGCWM2vjlY9KGl5OvZqY6d+7yO0mLV9GmQ==-----END RSA PRIVATE KEY-----"
+    And The setting "security-wantAssertionsSigned" is set to "1"
+    And The setting "localGroupsCheckForMigration" is set to '{\"dropAfter\":9223372036854775807,\"groups\":[\"Students\"]}'
+    And the local group "Astrophysics" is created
+    # Initial login so the user is known and belonging to SAML, directly followed by a logout
+    And I send a GET request to "http://localhost:8080/index.php/login"
+    And I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And I send a GET request with requesttoken to "http://localhost:8080/index.php/apps/user_saml/saml/sls"
+    And the user "student1" is added to the group "Astrophysics"
+    # Set the proper attributes
+    And The setting "saml-attribute-mapping-email_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.3"
+    And The setting "saml-attribute-mapping-displayName_mapping" is set to "urn:oid:2.5.4.42 urn:oid:2.5.4.4"
+    And The setting "saml-attribute-mapping-group_mapping" is set to "groups"
+    And the cookies are cleared
+    # Now login in for good
+    When I send a GET request to "http://localhost:8080/index.php/login"
+    Then I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And The user value "groups" should be "Astrophysics,SAML_Astrophysics,SAML_Students"
+    When I execute the background job for class "OCA\\User_SAML\\Jobs\\MigrateGroups"
+    Then the group backend of "Astrophysics" should be "Database"
+    And Then the group backend of "Astrophysics" must not be "user_saml"
+    And The user value "groups" should be "Astrophysics,SAML_Astrophysics,SAML_Students"
+
+  Scenario: Not migrating a local group to SAML backend when removing the last SAML user of it
+    Given The setting "type" is set to "saml"
+    And The setting "general-uid_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.1"
+    And The setting "idp-entityId" is set to "https://shibboleth-integration-nextcloud.localdomain/idp/shibboleth"
+    And The setting "idp-singleSignOnService.url" is set to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And The setting "idp-singleLogoutService.url" is set to "https://localhost:4443/idp/profile/Logout"
+    And The setting "idp-x509cert" is set to "MIIDnTCCAoWgAwIBAgIUGPx9uPjCu7c172IUgV84Tm94pBcwDQYJKoZIhvcNAQEL BQAwNzE1MDMGA1UEAwwsc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQu bG9jYWxkb21haW4wHhcNMTcwMTA0MTAxMTI3WhcNMzcwMTA0MTAxMTI3WjA3MTUw MwYDVQQDDCxzaGliYm9sZXRoLWludGVncmF0aW9uLW5leHRjbG91ZC5sb2NhbGRv bWFpbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKH+bPu45tk8/JRk XOxkyfbxocWZlY4mRumEUxscd3fn0oVzOrdWbHH7lCZV4bus4KxvJljc0Nm2K+Zr LoiRUUnf/LQ4LlehWVm5Kbc4kRgOXS0iGZN3SslAWPKyIg0tywg+TLOBPoS6EtST 1WuYg1JPMFxPfeFDWQ0dQYPlXIJWBFh6F2JMTb0FLECqA5l/ryYE13QisX5l+Mqo 6y3Dh7qIgaH0IJNobXoAcEWza7Kb2RnfhZRh9e0qjZIwBqTJUFM/6I86RYXn829s INUvYQQbez6VkGTdUQJ/GuXb/dD5sMQfOyK8hrRY5MozOmK32cz3JaAzSXpiSRS9 NxFwvicCAwEAAaOBoDCBnTAdBgNVHQ4EFgQUKn8+TV0WXSDeavvF0M8mWn1o8ukw fAYDVR0RBHUwc4Isc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQubG9j YWxkb21haW6GQ2h0dHBzOi8vc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xv dWQubG9jYWxkb21haW4vaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEB ABI6uzoIeLZT9Az2KTlLxIc6jZ4MDmhaVja4ZuBxTXEb7BFLfeASEJmQm1wgIMOn pJId3Kh3njW+3tOBWKm7lj8JxVVpAu4yMFSoQGPaVUgYB1AVm+pmAyPLzfJ/XGhf esCU2F/b0eHWcaIb3x+BZFX089Cd/PBtP84MNXdo+TccibxC8N39sr45qJM/7SC7 TfDYU0L4q2WZHJr4S7+0F+F4KaxLx9NzCvN4h6XaoWofZWir2iHO4NzbrVQGC0ei QybS/neBfni4A2g1lyzCb6xFB58JBvNCn7AAnDJULOE7S5XWUKsDAQVQrxTNkUq7 pnhlCQqZDwUdgmIXd1KB1So="
+    And The setting "security-authnRequestsSigned" is set to "1"
+    And The setting "security-wantAssertionsEncrypted" is set to "1"
+    And The setting "sp-x509cert" is set to "-----BEGIN CERTIFICATE-----MIIC+zCCAeOgAwIBAgIJAIgZuvWDBIrdMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xNzAxMDQxMTM5MjFaFw0yNzAxMDIxMTM5MjFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN3ESWaDH1JiJTy9yRJQV7kahPOxgBkIH2xwcYDL1k9deKNhSKLx7aGfxE244+HBcC6WLHKVUnOm0ld2qxQ4bMYiJXzZuqL67r07L5wxGAssv12lO92qohGmlHy3+VzRYUBmovu6upqOv3R2F8HBbo7Jc7Hvt7hOEJn/jPuFuF/fHit3mqU8l6IkrIZjpaW8T9fIWOXRq98U4+hkgWpqEZWsqlfE8BxAs9DeIMZab0GxO9stHLp+GYKx10uE4ezFcaDS8W+g2C8enCTt1HXGvcnj4o5zkC1lITGvcFTsiFqfIWyXeSufcxdc0W7HoG6J3ks0WJyK38sfFn0t2Ao6kX0CAwEAAaNQME4wHQYDVR0OBBYEFAoJzX6TVYAwC1GSPe6nObBG54zaMB8GA1UdIwQYMBaAFAoJzX6TVYAwC1GSPe6nObBG54zaMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJia9R70uXdUZtgujUPjLas4+sVajzlBFmqhBqpLAo934vljf9HISsHrPtdBcbS0d0rucqXwabDf0MlR18ksnT/NYpsTwMbMx76CrXi4zYEEW5lISKEO65aIkzVTcqKWSuhjtSnRdB6iOLsFiKmNMWXaIKMR5T0+AbR9wdQgn08W+3EEeHGvafVQfE3STVsSgNb1ft7DvcSUnfPXGU7KzvmTpZa0Hfmc7uY4vpdEEhLAdRhgLReS7USZskov7ooiPSoD+JRFi2gM4klBxTemHdNUa9oFnHMXuYKOkLbkgFvHxyy+QlLq2ELQTga5e7I83ZyOfGctyf8Ul6vGw10vbQ=-----END CERTIFICATE-----"
+    And The setting "sp-privateKey" is set to "-----BEGIN RSA PRIVATE KEY-----MIIEpAIBAAKCAQEA3cRJZoMfUmIlPL3JElBXuRqE87GAGQgfbHBxgMvWT114o2FIovHtoZ/ETbjj4cFwLpYscpVSc6bSV3arFDhsxiIlfNm6ovruvTsvnDEYCyy/XaU73aqiEaaUfLf5XNFhQGai+7q6mo6/dHYXwcFujslzse+3uE4Qmf+M+4W4X98eK3eapTyXoiSshmOlpbxP18hY5dGr3xTj6GSBamoRlayqV8TwHECz0N4gxlpvQbE72y0cun4ZgrHXS4Th7MVxoNLxb6DYLx6cJO3Udca9yePijnOQLWUhMa9wVOyIWp8hbJd5K59zF1zRbsegboneSzRYnIrfyx8WfS3YCjqRfQIDAQABAoIBAQC5CQAdcqZ9vLpJNilBCJxJLCFmm+HAAREHD8MErg9A5UK1P4S1wJp/0qieGPi68wXBOTgY2xKSwMycgb04/+NyZidVRu388takOW/+KNBg8pMxdZ6/05GqnI0kivSbR3CXpYuz8hekwhpo9+fWmKjApsHL47ItK6WaeKmPbAFsq1YJGzfp/DXg7LIvh9GA3C1LWWGV7SuCGOyX/2Moi8xRa7qBtH4hDo/0NRhTx7zjYjlBgNEr330pJUopc3+AtHE40R+xMr2zkGvq9RsCZxYxD2VWbLwQW0yNjWmQ2OTuMgJJvk2+N73QLHcB+tea82ZTszsNzRS9DLtc6qbsKEPZAoGBAO78U3vEuRyY56f/1hpo0xuCDwOkWGzgBQWkjJl6dlyVz/zKkhXBHpEYImyt8XRN0W3iGZYpZ2hCFJGTcDp32R6UiEyGLz0Uc8R/tva/TiRVW1FdNczzSHcB24b9OMK4vE9JLs8mA8Rp8YBgtLr5DDuMfYt/a/rZJbg/HIfIN98nAoGBAO2OInCX93t2I6zzRPIqKtI6q6FYNp64VIQjvw9Y8l0x3IdJZRP9H5C8ZhCeYPsgEqTXcXa4j5hL4rQzoUtxfxflBUUH60bcnd4LGaTCMYLS14G011E3GZlIP0sJi5OjEhy8fq3zt6jVzS9V/lPHB8i+w1D7CbPrMpW7B3k32vC7AoGAX/HvdkYhZyjAAEOG6m1hK68IZhbp5TP+8CgCxm9S65K9wKh3A8LXibrdvzIKOP4w8WOPkCipOkMlTNibeu24vj01hztr5aK7Y40+oEtnjNCz67N3MQQO+LBHOSeaTRqrh01DPKjvZECAU2D/zfzEe3fIw2Nxr3DUYub7hkvMmosCgYAzxbVVypjiLGYsDDyrdmsstCKxoDMPNmcdAVljc+QmUXaZeXJw/8qAVb78wjeqo1vM1zNgR2rsKyW2VkZB1fN39q7GU6qAIBa7zLmDAduegmr7VrlSduq6UFeS9/qWa4TIBICrUqFlR2tXdKtgANF+e6y/mmaL8qdsoH1JetXZfwKBgQC1vscRpdAXivjOOZAh+mzJWzS4BUl4CTJLYYIuOEXikmN5g0EdV2fhUEdkewmyKnXHsd0x83167bYgpTDNs71jUxDHy5NXlg2qIjLkf09X9wr19gBzDApfWzfh3vUqttyMZuQMLVNepGCWM2vjlY9KGl5OvZqY6d+7yO0mLV9GmQ==-----END RSA PRIVATE KEY-----"
+    And The setting "security-wantAssertionsSigned" is set to "1"
+    And The setting "localGroupsCheckForMigration" is set to '{\"dropAfter\":9223372036854775807,\"groups\":[\"Archaeologists\", \"Astrophysics\",\"Students\"]}'
+    And the local group "Archaeologists" is created
+    # Initial login so the user is known and belonging to SAML, directly followed by a logout
+    And I send a GET request to "http://localhost:8080/index.php/login"
+    And I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And I send a GET request with requesttoken to "http://localhost:8080/index.php/apps/user_saml/saml/sls"
+    # Set the proper attributes
+    And The setting "saml-attribute-mapping-email_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.3"
+    And The setting "saml-attribute-mapping-displayName_mapping" is set to "urn:oid:2.5.4.42 urn:oid:2.5.4.4"
+    And The setting "saml-attribute-mapping-group_mapping" is set to "groups"
+    And the cookies are cleared
+    And the user "student1" is added to the group "Archaeologists"
+    # Now login in for good
+    When I send a GET request to "http://localhost:8080/index.php/login"
+    Then I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    #And I should be redirected to "http://localhost:8080/index.php/apps/dashboard/"
+    And The user value "groups" should be "SAML_Astrophysics,SAML_Students"
+    And the group backend of "Archaeologists" should be "Database"
+    And Then the group backend of "Archaeologists" must not be "user_saml"
+    When I execute the background job for class "OCA\\User_SAML\\Jobs\\MigrateGroups"
+    Then the group backend of "Archaeologists" should be "Database"
+    And Then the group backend of "Archaeologists" must not be "user_saml"
+    And The user value "groups" should be "SAML_Astrophysics,SAML_Students"
+
+  Scenario: Removing a previously assigned SAML group
+    Given The setting "type" is set to "saml"
+    And The setting "general-uid_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.1"
+    And The setting "idp-entityId" is set to "https://shibboleth-integration-nextcloud.localdomain/idp/shibboleth"
+    And The setting "idp-singleSignOnService.url" is set to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And The setting "idp-singleLogoutService.url" is set to "https://localhost:4443/idp/profile/Logout"
+    And The setting "idp-x509cert" is set to "MIIDnTCCAoWgAwIBAgIUGPx9uPjCu7c172IUgV84Tm94pBcwDQYJKoZIhvcNAQEL BQAwNzE1MDMGA1UEAwwsc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQu bG9jYWxkb21haW4wHhcNMTcwMTA0MTAxMTI3WhcNMzcwMTA0MTAxMTI3WjA3MTUw MwYDVQQDDCxzaGliYm9sZXRoLWludGVncmF0aW9uLW5leHRjbG91ZC5sb2NhbGRv bWFpbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKH+bPu45tk8/JRk XOxkyfbxocWZlY4mRumEUxscd3fn0oVzOrdWbHH7lCZV4bus4KxvJljc0Nm2K+Zr LoiRUUnf/LQ4LlehWVm5Kbc4kRgOXS0iGZN3SslAWPKyIg0tywg+TLOBPoS6EtST 1WuYg1JPMFxPfeFDWQ0dQYPlXIJWBFh6F2JMTb0FLECqA5l/ryYE13QisX5l+Mqo 6y3Dh7qIgaH0IJNobXoAcEWza7Kb2RnfhZRh9e0qjZIwBqTJUFM/6I86RYXn829s INUvYQQbez6VkGTdUQJ/GuXb/dD5sMQfOyK8hrRY5MozOmK32cz3JaAzSXpiSRS9 NxFwvicCAwEAAaOBoDCBnTAdBgNVHQ4EFgQUKn8+TV0WXSDeavvF0M8mWn1o8ukw fAYDVR0RBHUwc4Isc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xvdWQubG9j YWxkb21haW6GQ2h0dHBzOi8vc2hpYmJvbGV0aC1pbnRlZ3JhdGlvbi1uZXh0Y2xv dWQubG9jYWxkb21haW4vaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEB ABI6uzoIeLZT9Az2KTlLxIc6jZ4MDmhaVja4ZuBxTXEb7BFLfeASEJmQm1wgIMOn pJId3Kh3njW+3tOBWKm7lj8JxVVpAu4yMFSoQGPaVUgYB1AVm+pmAyPLzfJ/XGhf esCU2F/b0eHWcaIb3x+BZFX089Cd/PBtP84MNXdo+TccibxC8N39sr45qJM/7SC7 TfDYU0L4q2WZHJr4S7+0F+F4KaxLx9NzCvN4h6XaoWofZWir2iHO4NzbrVQGC0ei QybS/neBfni4A2g1lyzCb6xFB58JBvNCn7AAnDJULOE7S5XWUKsDAQVQrxTNkUq7 pnhlCQqZDwUdgmIXd1KB1So="
+    And The setting "security-authnRequestsSigned" is set to "1"
+    And The setting "security-wantAssertionsEncrypted" is set to "1"
+    And The setting "sp-x509cert" is set to "-----BEGIN CERTIFICATE-----MIIC+zCCAeOgAwIBAgIJAIgZuvWDBIrdMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xNzAxMDQxMTM5MjFaFw0yNzAxMDIxMTM5MjFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN3ESWaDH1JiJTy9yRJQV7kahPOxgBkIH2xwcYDL1k9deKNhSKLx7aGfxE244+HBcC6WLHKVUnOm0ld2qxQ4bMYiJXzZuqL67r07L5wxGAssv12lO92qohGmlHy3+VzRYUBmovu6upqOv3R2F8HBbo7Jc7Hvt7hOEJn/jPuFuF/fHit3mqU8l6IkrIZjpaW8T9fIWOXRq98U4+hkgWpqEZWsqlfE8BxAs9DeIMZab0GxO9stHLp+GYKx10uE4ezFcaDS8W+g2C8enCTt1HXGvcnj4o5zkC1lITGvcFTsiFqfIWyXeSufcxdc0W7HoG6J3ks0WJyK38sfFn0t2Ao6kX0CAwEAAaNQME4wHQYDVR0OBBYEFAoJzX6TVYAwC1GSPe6nObBG54zaMB8GA1UdIwQYMBaAFAoJzX6TVYAwC1GSPe6nObBG54zaMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJia9R70uXdUZtgujUPjLas4+sVajzlBFmqhBqpLAo934vljf9HISsHrPtdBcbS0d0rucqXwabDf0MlR18ksnT/NYpsTwMbMx76CrXi4zYEEW5lISKEO65aIkzVTcqKWSuhjtSnRdB6iOLsFiKmNMWXaIKMR5T0+AbR9wdQgn08W+3EEeHGvafVQfE3STVsSgNb1ft7DvcSUnfPXGU7KzvmTpZa0Hfmc7uY4vpdEEhLAdRhgLReS7USZskov7ooiPSoD+JRFi2gM4klBxTemHdNUa9oFnHMXuYKOkLbkgFvHxyy+QlLq2ELQTga5e7I83ZyOfGctyf8Ul6vGw10vbQ=-----END CERTIFICATE-----"
+    And The setting "sp-privateKey" is set to "-----BEGIN RSA PRIVATE KEY-----MIIEpAIBAAKCAQEA3cRJZoMfUmIlPL3JElBXuRqE87GAGQgfbHBxgMvWT114o2FIovHtoZ/ETbjj4cFwLpYscpVSc6bSV3arFDhsxiIlfNm6ovruvTsvnDEYCyy/XaU73aqiEaaUfLf5XNFhQGai+7q6mo6/dHYXwcFujslzse+3uE4Qmf+M+4W4X98eK3eapTyXoiSshmOlpbxP18hY5dGr3xTj6GSBamoRlayqV8TwHECz0N4gxlpvQbE72y0cun4ZgrHXS4Th7MVxoNLxb6DYLx6cJO3Udca9yePijnOQLWUhMa9wVOyIWp8hbJd5K59zF1zRbsegboneSzRYnIrfyx8WfS3YCjqRfQIDAQABAoIBAQC5CQAdcqZ9vLpJNilBCJxJLCFmm+HAAREHD8MErg9A5UK1P4S1wJp/0qieGPi68wXBOTgY2xKSwMycgb04/+NyZidVRu388takOW/+KNBg8pMxdZ6/05GqnI0kivSbR3CXpYuz8hekwhpo9+fWmKjApsHL47ItK6WaeKmPbAFsq1YJGzfp/DXg7LIvh9GA3C1LWWGV7SuCGOyX/2Moi8xRa7qBtH4hDo/0NRhTx7zjYjlBgNEr330pJUopc3+AtHE40R+xMr2zkGvq9RsCZxYxD2VWbLwQW0yNjWmQ2OTuMgJJvk2+N73QLHcB+tea82ZTszsNzRS9DLtc6qbsKEPZAoGBAO78U3vEuRyY56f/1hpo0xuCDwOkWGzgBQWkjJl6dlyVz/zKkhXBHpEYImyt8XRN0W3iGZYpZ2hCFJGTcDp32R6UiEyGLz0Uc8R/tva/TiRVW1FdNczzSHcB24b9OMK4vE9JLs8mA8Rp8YBgtLr5DDuMfYt/a/rZJbg/HIfIN98nAoGBAO2OInCX93t2I6zzRPIqKtI6q6FYNp64VIQjvw9Y8l0x3IdJZRP9H5C8ZhCeYPsgEqTXcXa4j5hL4rQzoUtxfxflBUUH60bcnd4LGaTCMYLS14G011E3GZlIP0sJi5OjEhy8fq3zt6jVzS9V/lPHB8i+w1D7CbPrMpW7B3k32vC7AoGAX/HvdkYhZyjAAEOG6m1hK68IZhbp5TP+8CgCxm9S65K9wKh3A8LXibrdvzIKOP4w8WOPkCipOkMlTNibeu24vj01hztr5aK7Y40+oEtnjNCz67N3MQQO+LBHOSeaTRqrh01DPKjvZECAU2D/zfzEe3fIw2Nxr3DUYub7hkvMmosCgYAzxbVVypjiLGYsDDyrdmsstCKxoDMPNmcdAVljc+QmUXaZeXJw/8qAVb78wjeqo1vM1zNgR2rsKyW2VkZB1fN39q7GU6qAIBa7zLmDAduegmr7VrlSduq6UFeS9/qWa4TIBICrUqFlR2tXdKtgANF+e6y/mmaL8qdsoH1JetXZfwKBgQC1vscRpdAXivjOOZAh+mzJWzS4BUl4CTJLYYIuOEXikmN5g0EdV2fhUEdkewmyKnXHsd0x83167bYgpTDNs71jUxDHy5NXlg2qIjLkf09X9wr19gBzDApfWzfh3vUqttyMZuQMLVNepGCWM2vjlY9KGl5OvZqY6d+7yO0mLV9GmQ==-----END RSA PRIVATE KEY-----"
+    And The setting "security-wantAssertionsSigned" is set to "1"
+    # Initial login so the user is known and belonging to SAML, directly followed by a logout
+    And I send a GET request to "http://localhost:8080/index.php/login"
+    And I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And I send a GET request with requesttoken to "http://localhost:8080/index.php/apps/user_saml/saml/sls"
+    And the cookies are cleared
+    # Set the proper attributes
+    And The setting "saml-attribute-mapping-email_mapping" is set to "urn:oid:0.9.2342.19200300.100.1.3"
+    And The setting "saml-attribute-mapping-displayName_mapping" is set to "urn:oid:2.5.4.42 urn:oid:2.5.4.4"
+    And The setting "saml-attribute-mapping-group_mapping" is set to "groups"
+    # Pull in an extra SAML group via another user
+    And I send a GET request to "http://localhost:8080/index.php/login"
+    And I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student1  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And I send a GET request with requesttoken to "http://localhost:8080/index.php/apps/user_saml/saml/sls"
+    And the cookies are cleared
+    And the user "student2" is added to the group "SAML_Archaeologists"
+    # Now login in for good
+    When I send a GET request to "http://localhost:8080/index.php/login"
+    Then I should be redirected to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO"
+    And I send a POST request to "https://localhost:4443/idp/profile/SAML2/Redirect/SSO?execution=e1s1" with the following data
+      |j_username|j_password|_eventId_proceed|
+      |student2  |password  |                |
+    And The response should be a SAML redirect page that gets submitted
+    And The user value "groups" should be "SAML_Students"

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -92,6 +92,11 @@
       <code>getConfigurationArray</code>
     </UndefinedMagicMethod>
   </file>
+  <file src="lib/GroupBackend.php">
+    <LessSpecificImplementedReturnType>
+      <code>string[]</code>
+    </LessSpecificImplementedReturnType>
+  </file>
   <file src="lib/Middleware/OnlyLoggedInMiddleware.php">
     <DeprecatedMethod>
       <code>hasAnnotation</code>

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -5,3 +5,25 @@ namespace OCA\Files\Event {
 	class LoadAdditionalScriptsEvent extends Event {
 	}
 }
+
+namespace OC\Group {
+	abstract class Database extends \OCP\Group\Backend\ABackend implements
+		\OCP\Group\Backend\IAddToGroupBackend,
+		\OCP\Group\Backend\ICountDisabledInGroup,
+		\OCP\Group\Backend\ICountUsersBackend,
+		\OCP\Group\Backend\ICreateGroupBackend,
+		\OCP\Group\Backend\IDeleteGroupBackend,
+		\OCP\Group\Backend\IGetDisplayNameBackend,
+		\OCP\Group\Backend\IGroupDetailsBackend,
+		\OCP\Group\Backend\IRemoveFromGroupBackend,
+		\OCP\Group\Backend\ISetDisplayNameBackend,
+		\OCP\Group\Backend\ISearchableGroupBackend,
+		\OCP\Group\Backend\INamedBackend {
+	}
+}
+
+namespace OC\Hooks {
+	interface PublicEmitter {
+		public function emit($scope, $method, array $arguments = []);
+	}
+}

--- a/tests/unit/GroupBackendTest.php
+++ b/tests/unit/GroupBackendTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Dominik Ach <da@infodatacom.de>
+ *
+ * @author Dominik Ach <da@infodatacom.de>
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ * @author Carl Schwan <carl@carlschwan.eu>
+ * @author Maximilian Ruta <mr@xtain.net>
+ * @author Jonathan Treffler <mail@jonathan-treffler.de>
+ * @author Giuliano Mele <giuliano.mele@verdigado.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use \OCA\User_SAML\GroupBackend;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class GroupBackendTest extends TestCase {
+
+	/** @var GroupBackend */
+	private static $groupBackend;
+	private static $users = [
+		[
+			'uid' => 'user_saml_integration_test_uid1',
+			'groups' => [
+				'user_saml_integration_test_gid1',
+				'SAML_user_saml_integration_test_gid2'
+			]
+		],
+		[
+			'uid' => 'user_saml_integration_test_uid2',
+			'groups' => [
+				'user_saml_integration_test_gid1'
+			]
+		]
+	];
+	private static $groups = [
+		[
+			'gid' => 'user_saml_integration_test_gid1',
+			'saml_gid' => 'user_saml_integration_test_gid1',
+			'members' => [
+				'user_saml_integration_test_uid1',
+				'user_saml_integration_test_uid2'
+			],
+			'saml_gid_exists' => true
+		],
+		[
+			'gid' => 'SAML_user_saml_integration_test_gid2',
+			'saml_gid' => 'user_saml_integration_test_gid2',
+			'members' => [
+				'user_saml_integration_test_uid1'
+			],
+			'saml_gid_exists' => false
+		],
+		[
+			'gid' => 'user_saml_integration_test_gid3',
+			'saml_gid' => 'user_saml_integration_test_gid3',
+			'members' => [],
+			'saml_gid_exists' => true
+		],
+	];
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::$groupBackend = new \OCA\User_SAML\GroupBackend(\OC::$server->getDatabaseConnection());
+		foreach (self::$groups as $group) {
+			self::$groupBackend->createGroup($group['gid'], $group['saml_gid']);
+		}
+		foreach (self::$users as $user) {
+			foreach ($user['groups'] as $group) {
+				self::$groupBackend->addToGroup($user['uid'], $group);
+			}
+		}
+	}
+
+	public static function tearDownAfterClass(): void {
+		parent::tearDownAfterClass();
+		self::$groupBackend = new \OCA\User_SAML\GroupBackend(\OC::$server->getDatabaseConnection());
+		foreach (self::$users as $user) {
+			foreach ($user['groups'] as $group) {
+				self::$groupBackend->removeFromGroup($user['uid'], $group);
+			}
+		}
+		foreach (self::$groups as $group) {
+			self::$groupBackend->deleteGroup($group['gid']);
+		}
+	}
+
+	public function testInGroup() {
+		foreach (self::$groups as $group) {
+			foreach (self::$users as $user) {
+				$result = self::$groupBackend->inGroup($user['uid'], $group['gid']);
+				if (in_array($group['gid'], $user['groups'])) {
+					$this->assertTrue($result, sprintf("User %s should be member of group %s", $user['uid'], $group['gid']));
+				} else {
+					$this->assertFalse($result, sprintf("User %s should not be member of group %s", $user['uid'], $group['gid']));
+				}
+			}
+		}
+	}
+
+	public function testGetGroups() {
+		$groups = self::$groupBackend->getGroups();
+		foreach (self::$groups as $group) {
+			$this->assertContains($group['gid'], $groups, sprintf('Group %s should be retrieved', $group['gid']));
+		}
+	}
+
+	public function testGetUserGroups() {
+		foreach (self::$users as $user) {
+			$userGroups = self::$groupBackend->getUserGroups($user['uid']);
+			$this->assertCount(count($user['groups']), $userGroups, 'Should retrieve all user groups');
+			foreach ($userGroups as $userGroup) {
+				$this->assertContains($userGroup, $user['groups'], sprintf('Users %s should be member of groups %s', $user['uid'], $userGroup));
+			}
+		}
+	}
+
+	public function testGroupExists() {
+		foreach (self::$groups as $group) {
+			$result = self::$groupBackend->groupExists($group['saml_gid']);
+			$this->assertSame($group['saml_gid_exists'], $result, sprintf('Group %s should exist', $group['saml_gid']));
+		}
+	}
+
+	public function testUsersInGroups() {
+		foreach (self::$groups as $group) {
+			$users = self::$groupBackend->usersInGroup($group['gid']);
+			$this->assertCount(count($group['members']), $users, 'Should retrieve all group members');
+			foreach ($users as $user) {
+				$this->assertContains($user, $group['members'], sprintf('User %s should be member of group %s', $user, $group['gid']));
+			}
+		}
+	}
+}

--- a/tests/unit/GroupManagerTest.php
+++ b/tests/unit/GroupManagerTest.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021 Giuliano Mele <giuliano.mele@verdigado.com>
+ *
+ * @author Giuliano Mele <giuliano.mele@verdigado.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Tests;
+
+use OC\BackgroundJob\JobList;
+use OC\Group\Manager;
+use OCA\User_SAML\GroupBackend;
+use OCA\User_SAML\GroupManager;
+use OCA\User_SAML\SAMLSettings;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class GroupManagerTest extends TestCase {
+
+	/** @var IDBConnection|MockObject */
+	private $db;
+	/** @var IGroupManager|MockObject */
+	private $groupManager;
+	/** @var GroupBackend|MockObject */
+	private $ownGroupBackend;
+	/** @var IConfig|MockObject */
+	private $config;
+	/** @var JobList|MockObject */
+	private $jobList;
+	/** @var SAMLSettings|MockObject */
+	private $settings;
+	/** @var GroupManager|MockObject */
+	private $ownGroupManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->groupManager = $this->createMock(Manager::class);
+		$this->ownGroupBackend = $this->createMock(GroupBackend::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->jobList = $this->createMock(JobList::class);
+		$this->settings = $this->createMock(SAMLSettings::class);
+		$this->ownGroupManager = $this->createMock(GroupManager::class);
+	}
+
+	public function getGroupManager(array $mockedFunctions = []) {
+		if (!empty($mockedFunctions)) {
+			$this->ownGroupManager = $this->getMockBuilder(GroupManager::class)
+				->setConstructorArgs([
+					$this->db,
+					$this->groupManager,
+					$this->ownGroupBackend,
+					$this->config,
+					$this->jobList,
+					$this->settings
+				])
+				->onlyMethods($mockedFunctions)
+				->getMock();
+		} else {
+			$this->ownGroupManager = new GroupManager(
+				$this->db,
+				$this->groupManager,
+				$this->ownGroupBackend,
+				$this->config,
+				$this->jobList,
+				$this->settings
+			);
+		}
+	}
+
+	public function testUpdateUserGroups() {
+		// Case: The known memberships of the user are groupA and groupB. The new
+		// memberships are GroupB and GroupC. Hence, the user must be unassigned
+		// from GroupA and assigned to GroupC, while the GroupB association remains
+		// unchanged.
+
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->with('user_saml', GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '')
+			->willReturn(\json_encode(['groups' => ['groupA'], 'dropAfter' => time() + 2000]));
+
+		$this->getGroupManager(['handleUserUnassignedFromGroups', 'handleUserAssignedToGroups', 'translateGroupToIds', 'hasSamlBackend']);
+		$user = $this->createMock(IUser::class);
+		$groupA = $this->createMock(IGroup::class);
+		$groupA
+			->method('getBackendNames')
+			->willReturn(['Database']);
+		$groupA->method('getGID')
+			->willReturn('groupA');
+		$groupB = $this->createMock(IGroup::class);
+		$groupB
+			->method('getBackendNames')
+			->willReturn(['Database']);
+		$groupB->method('getGID')
+			->willReturn('groupB');
+		$this->ownGroupManager
+			->expects($this->once())
+			->method('translateGroupToIds')
+			->with(['groupB', 'groupC']);
+		// assert user is actually assigned to groupA and groupB
+		$this->groupManager
+			->expects($this->once())
+			->method('getUserGroups')
+			->with($user)
+			->willReturn([$groupA, $groupB]);
+		$this->groupManager
+			->method('get')
+			->willReturnCallback(function ($groupId) use ($groupA, $groupB): ?IGroup {
+				switch ($groupId) {
+					case 'groupA':
+						return $groupA;
+					case 'groupB':
+						return $groupB;
+					default:
+						return null;
+				}
+			});
+		// assert all groups are supplied by SAML backend
+		$this->ownGroupManager
+			->method('hasSamlBackend')
+			->willReturn(true);
+		// assert removing membership to groupA
+		$this->ownGroupManager
+			->expects($this->once())
+			->method('handleUserUnassignedFromGroups')
+			->with($user, ['groupA']);
+		// assert adding membership to groupC
+		$this->ownGroupManager
+			->expects($this->once())
+			->method('handleUserAssignedToGroups')
+			->with($user, ['groupC']);
+
+		// assert SAML provides user groups groupB and groupC
+		$this->ownGroupManager->updateUserGroups($user, ['groupB', 'groupC']);
+	}
+
+	public function testUnassignUserFromGroups() {
+		$this->getGroupManager();
+		$user = $this->createMock(IUser::class);
+		$groupA = $this->createMock(IGroup::class);
+		$groupA->method('getBackendNames')
+			->willReturn(['Database', 'user_saml']);
+		$this->groupManager
+			->method('get')
+			->with('groupA')
+			->willReturn($groupA);
+		$user->expects($this->once())
+			->method('getUID')
+			->willReturn('uid');
+		$groupA->expects($this->exactly(2))
+			->method('getGID')
+			->willReturn('gid');
+		// assert membership gets removed
+		$this->ownGroupBackend
+			->expects($this->once())
+			->method('removeFromGroup');
+		// assert no remaining group memberships
+		$this->ownGroupBackend
+			->expects($this->once())
+			->method('countUsersInGroup')
+			->willReturn(0);
+		// assert group is deleted
+		$this->ownGroupBackend
+			->expects($this->once())
+			->method('deleteGroup');
+
+		$this->invokePrivate($this->ownGroupManager, 'handleUserUnassignedFromGroups', [$user, ['groupA']]);
+	}
+
+	public function testAssignUserToGroups() {
+		$this->getGroupManager(['hasSamlBackend', 'createGroupInBackend']);
+		$user = $this->createMock(IUser::class);
+		$groupA = $this->createMock(IGroup::class);
+
+		// assert group already exists
+		$this->groupManager
+			->expects($this->once())
+			->method('get')
+			->with('groupA')
+			->willReturn($groupA);
+		// assert SAML group backend
+		$this->ownGroupManager
+			->expects($this->once())
+			->method('hasSamlBackend')
+			->willReturn(true);
+		$groupA->expects($this->once())
+			->method('addUser')
+			->with($user);
+		$this->ownGroupManager
+			->expects($this->never())
+			->method('createGroupInBackend');
+
+		$this->invokePrivate($this->ownGroupManager, 'handleUserAssignedToGroups', [$user, ['groupA']]);
+	}
+
+	public function testAssignUserToNonExistingGroups() {
+		$this->getGroupManager();
+		$user = $this->createMock(IUser::class);
+		$groupB = $this->createMock(IGroup::class);
+
+		// assert group does not exist
+		$this->groupManager
+			->method('get')
+			->willReturnOnConsecutiveCalls(null, $groupB);
+		// assert group is created
+		$this->ownGroupBackend
+			->expects($this->once())
+			->method('createGroup')
+			->with('groupB', 'groupB')
+			->willReturn(true);
+		// assert user gets added to group
+		$groupB->expects($this->once())
+			->method('addUser')
+			->with($user);
+
+		$this->invokePrivate($this->ownGroupManager, 'handleUserAssignedToGroups', [$user, ['groupB']]);
+	}
+
+	public function testAssignUserToGroupsWithCollision() {
+		$this->getGroupManager(['hasSamlBackend']);
+		$user = $this->createMock(IUser::class);
+		$groupC = $this->createMock(IGroup::class);
+
+		// assert group exists
+		$this->groupManager
+			->method('get')
+			->willReturnCallback(function ($groupId) use ($groupC) {
+				switch ($groupId) {
+					case 'groupC':
+						return $groupC;
+					case 'SAML_groupC':
+						return $groupC;
+				}
+				return null;
+			});
+		// assert differnt group backend
+		$this->ownGroupManager
+			->expects($this->once())
+			->method('hasSamlBackend')
+			->willReturn(false);
+		// assert there is only one idp config present
+		$this->settings
+			->expects($this->once())
+			->method('getProviderId');
+		// assert the default group prefix is configured
+		$this->settings
+			->method('get');
+		// assert group is created with prefix + gid
+		$this->ownGroupBackend
+			->expects($this->once())
+			->method('createGroup')
+			->with('SAML_groupC', 'groupC')
+			->willReturn(true);
+		// assert user gets added to group
+		$groupC->expects($this->once())
+			->method('addUser')
+			->with($user);
+
+		$this->invokePrivate($this->ownGroupManager, 'handleUserAssignedToGroups', [$user, ['groupC']]);
+	}
+}

--- a/tests/unit/GroupManagerTest.php
+++ b/tests/unit/GroupManagerTest.php
@@ -193,6 +193,11 @@ class GroupManagerTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$groupA = $this->createMock(IGroup::class);
 
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->with('user_saml', GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '')
+			->willReturnArgument(2);
+
 		// assert group already exists
 		$this->groupManager
 			->expects($this->once())
@@ -219,6 +224,11 @@ class GroupManagerTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$groupB = $this->createMock(IGroup::class);
 
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->with('user_saml', GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '')
+			->willReturnArgument(2);
+
 		// assert group does not exist
 		$this->groupManager
 			->method('get')
@@ -227,7 +237,7 @@ class GroupManagerTest extends TestCase {
 		$this->ownGroupBackend
 			->expects($this->once())
 			->method('createGroup')
-			->with('groupB', 'groupB')
+			->with('SAML_groupB', 'groupB')
 			->willReturn(true);
 		// assert user gets added to group
 		$groupB->expects($this->once())
@@ -241,6 +251,11 @@ class GroupManagerTest extends TestCase {
 		$this->getGroupManager(['hasSamlBackend']);
 		$user = $this->createMock(IUser::class);
 		$groupC = $this->createMock(IGroup::class);
+
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->with('user_saml', GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '')
+			->willReturnArgument(2);
 
 		// assert group exists
 		$this->groupManager

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -152,6 +152,11 @@ class AdminTest extends \Test\TestCase {
 				'type' => 'line',
 				'required' => false,
 			],
+			'group_mapping_prefix' => [
+				'text' => $this->l10n->t('Group Mapping Prefix, default: SAML_'),
+				'type' => 'line',
+				'required' => true,
+			],
 		];
 
 		$userFilterSettings = [


### PR DESCRIPTION
Work PR of #545, in good old tradition…  For it is not possible to push into #545 it's easier to have the feature branch here.

* [x] Default group mapping prefix is not shown in settings UI.
* [x] new table(s) are missing primary keys
* [x] consider membership changes in local groups during transition https://github.com/nextcloud/user_saml/pull/662#issuecomment-1336520574

## Group display names

In one of the predecessor PRs group display names were a topic, with the conclusion

> makeing use of group display names so present it more user friendly, perhaps with (SAML) in brackets.

The `(SAML)` suffix is in the code currently. While stated by the younger me, it does not make me very happy:

- typical for LTR languages only
- technical term exposed to potentially unwitting end users (why should they know about this detail
- We have a FIXME that is rather wondering about adding another config flag here…

I am going to revert this, to use the value as provided from SAML again. Besides avoiding the downsides mentioned above, the end user does not have to face a change and will not suffer irritation. Admins may need a closer look to verify the backend, if needed, which is totally fine imo.

## Group IDs

We have a group prefix `SAMLSettings::DEFAULT_GROUP_PREFIX`, that was brought back in the course of this work. At the momend it will only be used, to avoid name collisions. In hindsight this irritated me, I was expecting it to be considered independent of it (now only realizing that there is no way for an empty prefix).

I am not sure what to do about it. For, leaving it as it is results in an unpredictable behaviour of group ids, and groups may end up in an inconsistent naming manner: some with, some without prefix. 

Keeping old group ids however could actually be important to keep shares in place, or also permissions. On existing setups the "old" group does not go away, but it theoretically might be that a group wlll be split into ORIGINAL and SAML_ORIGINAL, where only the latter might be populated with new SAML users. In those cases, a doubled group display name  would cause more confusion with the admin. 

Having the prefix always present makes it more predictable, and while transition may need action of the admin, re-deployments would be reproducible.