### PR TITLE
user filtering only applicable with autoprov

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -165,6 +165,13 @@ class SAMLController extends Controller {
 	 * @throws UserFilterViolationException
 	 */
 	protected function assertGroupMemberships(): void {
+		if (!$this->userBackend->autoprovisionAllowed()) {
+			// return early, when users are provided by a different backend
+			// - mappings are not available/configurable in that case
+			// - control is solely based on presence and enabled-state of the user
+			return;
+		}
+
 		$groups = $this->userData->getGroups();
 		$settings = $this->samlSettings->get($this->session->get('user_saml.Idp') ?? 1);
 

--- a/tests/unit/Controller/SAMLControllerTest.php
+++ b/tests/unit/Controller/SAMLControllerTest.php
@@ -324,7 +324,7 @@ class SAMLControllerTest extends TestCase {
 			->method('getCurrentUserId')
 			->willReturn(isset($samlUserData['uid']) ? 'MyUid' : '');
 		$this->userBackend
-			->expects($autoProvision > 0 ? $this->once() : $this->any())
+			->expects($this->any())
 			->method('autoprovisionAllowed')
 			->willReturn($autoProvision > 0);
 		$this->userBackend
@@ -436,10 +436,28 @@ class SAMLControllerTest extends TestCase {
 			->with(1)
 			->willReturn($settings);
 
+		$this->userBackend->expects($this->any())
+			->method('autoprovisionAllowed')
+			->willReturn(true);
+
 		if ($isException) {
 			$this->expectException(UserFilterViolationException::class);
 			$this->expectExceptionMessage($message);
 		}
+
+		$this->invokePrivate($this->samlController, 'assertGroupMemberships');
+	}
+
+	public function testUserFilterNotApplicable(): void {
+		$this->userData->expects($this->never())
+			->method('getGroups');
+
+		$this->session->expects($this->never())
+			->method('get');
+
+		$this->userBackend->expects($this->any())
+			->method('autoprovisionAllowed')
+			->willReturn(false);
 
 		$this->invokePrivate($this->samlController, 'assertGroupMemberships');
 	}


### PR DESCRIPTION
When a provisioned account is required, it relies on another backend. Thus, allowing to auth depends on the presence of the user, and the enabled-state of the user.

Hence the configuration controls in the web UI are only shown when auto-provisioning is enabled. This change only implements a check and test cases in the business logic.

Follow up to #670 