### PR TITLE
Use session locking to be compatible with Nextcloud 25 during logout

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -429,6 +429,7 @@ class SAMLController extends Controller {
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @UseSession
 	 *
 	 * @return Http\RedirectResponse
 	 * @throws Error


### PR DESCRIPTION
Hotfix to fix https://github.com/nextcloud/server/issues/35708 but makes sense anyways to have consistent session locking for the full logout method.

https://github.com/nextcloud/server/pull/35723 could be considered hardening for the server method so this PR allows fixing the issue separtely without requiring the server PR.
