### PR TITLE
Pass an array of Idp on the foreach loop

### DIFF
--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -116,9 +116,11 @@ class SAMLSettings {
 		$this->ensureConfigurationsLoaded();
 
 		$result = [];
-		foreach ($this->configurations as $configID => $config) {
-			// no fancy array_* method, because there might be thousands
-			$result[$configID] = $config['general-idp0_display_name'] ?? '';
+		if (!empty($this->configurations) && is_array($this->configurations)) {
+			foreach ($this->configurations as $configID => $config) {
+				// no fancy array_* method, because there might be thousands
+				$result[$configID] = $config['general-idp0_display_name'] ?? '';
+			}
 		}
 
 		return $result;


### PR DESCRIPTION
Fix https://github.com/nextcloud/user_saml/issues/694

Ensure type safety by making sure that the `$this->configurations` variable is properly initialized and contains an array before the foreach loop is executed.