### PR TITLE
fix(login): do not hardcode IdP to 1 on redirect

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -199,7 +199,7 @@ if ($redirectSituation === true) {
 		[
 			'requesttoken' => $csrfToken->getEncryptedValue(),
 			'originalUrl' => $originalUrl,
-			'idp' => 1,
+			'idp' => array_keys($configuredIdps)[0] ?? '',
 		]
 	);
 	header('Location: '.$targetUrl);


### PR DESCRIPTION
Given: the only available SAML configuration has an ID > 1 and we have a redirect scenario, the the SAML backend was hard requiring the config with IdP 1. This fixed with this PR by using the first (and only) available identifier.