### PR TITLE
fix: Implement IGetDisplayNameBackend

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -36,10 +36,11 @@ use OCP\IUserBackend;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Server;
+use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Events\UserChangedEvent;
 use OCP\UserInterface;
 
-class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
+class UserBackend implements IApacheBackend, UserInterface, IUserBackend, IGetDisplayNameBackend {
 	/** @var IConfig */
 	private $config;
 	/** @var IURLGenerator */
@@ -308,9 +309,9 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 	 *
 	 * @param string $uid user ID of the user
 	 * @return string display name
-	 * @since 4.5.0
+	 * @since 14.0.0
 	 */
-	public function getDisplayName($uid) {
+	public function getDisplayName($uid): string {
 		if ($backend = $this->getActualUserBackend($uid)) {
 			return $backend->getDisplayName($uid);
 		} else {
@@ -328,7 +329,7 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 			}
 		}
 
-		return false;
+		return $uid;
 	}
 
 	/**
@@ -649,7 +650,7 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend {
 				&& $currentEmail !== $newEmail) {
 				$user->setEMailAddress($newEmail);
 			}
-			$currentDisplayname = (string)$this->getDisplayName($uid);
+			$currentDisplayname = $this->getDisplayName($uid);
 			if ($newDisplayname !== null
 				&& $currentDisplayname !== $newDisplayname) {
 				$this->eventDispatcher->dispatchTyped(new UserChangedEvent($user, 'displayName', $newDisplayname, $currentDisplayname));


### PR DESCRIPTION
Otherwise instanceof checks like https://github.com/nextcloud/server/pull/38298/files#diff-2e1b245993621bf5efdce546bacce8f0e43efb7bc5d0c8d1b8a55f17231c4158R79 would fail