### PR TITLE
[stable-5.2] fix(firstLogin): use compatible GenericEvent

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -22,7 +22,6 @@
 namespace OCA\User_SAML;
 
 use OCP\Authentication\IApacheBackend;
-use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\NotPermittedException;
 use OCP\IConfig;
@@ -37,6 +36,7 @@ use OCP\IUserManager;
 use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Events\UserChangedEvent;
 use OCP\UserInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class UserBackend implements IApacheBackend, UserInterface, IUserBackend, IGetDisplayNameBackend {
 	/** @var IConfig */


### PR DESCRIPTION
in NC 25 to 27 Symfony\Component\EventDispatcher\GenericEvent is expected with the old style ::firstLogin event

fixes #777 