### PR TITLE
fix(db): remove dead code and unused table

### DIFF
--- a/lib/Migration/Version3001Date20200630193443.php
+++ b/lib/Migration/Version3001Date20200630193443.php
@@ -62,30 +62,6 @@ class Version3001Date20200630193443 extends SimpleMigrationStep {
 			$table->setPrimaryKey(['uid']);
 		}
 
-		if (!$schema->hasTable('user_saml_auth_token')) {
-			$table = $schema->createTable('user_saml_auth_token');
-			$table->addColumn('id', Types::INTEGER, [
-				'autoincrement' => true,
-				'notnull' => true,
-				'length' => 4,
-				'unsigned' => true,
-			]);
-			$table->addColumn('uid', Types::STRING, [
-				'notnull' => true,
-				'length' => 64,
-				'default' => '',
-			]);
-			$table->addColumn('name', Types::TEXT, [
-				'notnull' => true,
-				'default' => '',
-			]);
-			$table->addColumn('token', Types::STRING, [
-				'notnull' => true,
-				'length' => 200,
-				'default' => '',
-			]);
-			$table->setPrimaryKey(['id']);
-		}
 		return $schema;
 	}
 }

--- a/lib/Migration/Version6001Date20240202183823.php
+++ b/lib/Migration/Version6001Date20240202183823.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_SAML\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version6001Date20240202183823 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if ($schema->hasTable('user_saml_auth_token')) {
+			$schema->dropTable('user_saml_auth_token');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -188,34 +188,6 @@ class UserBackend implements IApacheBackend, UserInterface, IUserBackend, IGetDi
 	}
 
 	/**
-	 * Check if the provided token is correct
-	 * @param string $uid The username
-	 * @param string $password The password
-	 * @return string
-	 *
-	 * Check if the password is correct without logging in the user
-	 * returns the user id or false
-	 */
-	public function checkPassword($uid, $password) {
-		$qb = $this->db->getQueryBuilder();
-		$qb->select('token')
-			->from('user_saml_auth_token')
-			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
-			->setMaxResults(1000);
-		$result = $qb->execute();
-		$data = $result->fetchAll();
-		$result->closeCursor();
-
-		foreach ($data as $passwords) {
-			if (password_verify($password, $passwords['token'])) {
-				return $uid;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * delete a user
 	 * @param string $uid The username of the user to delete
 	 * @return bool


### PR DESCRIPTION
- both table and logic where introduced with 84c1547c853081bf101528ecc60529e023ebc2ff
- … and were incompletely removed again in 9b97c7350bda2f12869b1301beffbf172570273b

Will have affect with a version bump only - will happen on release.

The `checkPassword` method was also not in use, because the `ICheckPasswordBackend` is not implemented :shrug: 