### PR TITLE
fix(UI): readable login dropdown chooser on dark mode

### DIFF
--- a/css/selectUserBackEnd.css
+++ b/css/selectUserBackEnd.css
@@ -2,8 +2,10 @@
 	color: var(--color-primary-text);
 }
 
-#saml-select-user-back-end #av_mode{
+#saml-select-user-back-end #av_mode {
 	height: auto;
+	background-color: var(--color-main-background);
+	color: var(--color-main-text);
 }
 
 #saml-select-user-back-end h1 {
@@ -12,7 +14,6 @@
 }
 
 .login-option {
-	background-color: var(--color-primary);
 	border: 1px solid var(--color-primary-text);
 	font-weight: 600;
 	height: 40px;

--- a/templates/selectUserBackEnd.php
+++ b/templates/selectUserBackEnd.php
@@ -16,7 +16,7 @@ Util::addScript('user_saml', 'selectUserBackEnd');
 	<?php if ($_['useCombobox']) { ?>
 
 		<select class="login-chose-saml-idp" id="av_mode" name="avMode">
-			<option value=""><?php p($l->t('Choose a authentication provider')); ?></option>
+			<option value=""><?php p($l->t('Choose an authentication provider')); ?></option>
 			<?php foreach ($_['loginUrls']['ssoLogin'] as $idp) { ?>
 				<option value="<?php p($idp['url']); ?>"><?php p($idp['display-name']); ?></option>
 			<?php } ?>


### PR DESCRIPTION
It got too annoying. When having enough options on SAML Login providers, we show a drop down. On black mode, the caption (*Choose an authentication provider*¹) was not readable, being black on almost black. The PR fixes is. No changes on light mode. 

| Before | After |
|---|---|
| ![saml-select-dropdown-before-dark](https://github.com/nextcloud/user_saml/assets/2184312/703e2d5f-896f-4c68-a6f5-e588a5a587eb) | ![saml-select-dropdown-after-dark](https://github.com/nextcloud/user_saml/assets/2184312/0611f575-b9ba-429a-a4a9-e85148a5f6c7) |
| ![saml-select-dropdown-before-light](https://github.com/nextcloud/user_saml/assets/2184312/c599d661-ae70-4e53-b0da-3e6cd986a49f) | ![saml-select-dropdown-after-light](https://github.com/nextcloud/user_saml/assets/2184312/f37a00f4-6107-4e93-9958-d637a8e1c2a0) |

¹I fixed the grammar after taking screenshots