### PR TITLE
Revert "build(dependabot): commit vendor files in 3rdparty"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     time: "03:00"
     timezone: Europe/Paris
   open-pull-requests-limit: 10
-  vendor: true
 - package-ecosystem: composer
   directory: "/"
   schedule:


### PR DESCRIPTION
Reverts nextcloud/user_saml#751

cf. https://github.com/nextcloud/user_saml/pull/751#issuecomment-1638721012 

now CI turns also red, cf. https://github.com/nextcloud/user_saml/pull/841


![Screenshot_20240510_152641](https://github.com/nextcloud/user_saml/assets/2184312/af9dc13a-c6eb-4990-ba11-471ad3eabf12)
