### PR TITLE
feat(groups): add setting display name to group backend

### DIFF
--- a/lib/GroupBackend.php
+++ b/lib/GroupBackend.php
@@ -81,7 +81,7 @@ class GroupBackend extends ABackend implements IAddToGroupBackend, ICountUsersBa
 			)));
 			$query->orWhere($query->expr()->iLike('displayname', $query->createNamedParameter(
 				'%' . $this->dbc->escapeLikeParameter($search) . '%'
-			))); 
+			)));
 		}
 
 		if ((int)$limit > 0) {
@@ -305,16 +305,18 @@ class GroupBackend extends ABackend implements IAddToGroupBackend, ICountUsersBa
 		$displayName = trim($displayName);
 		if ($displayName === '') {
 			$displayName = $gid;
-		} 
+		}
 
 		$query = $this->dbc->getQueryBuilder();
-		$query->update(self::TABLE_GROUPS)
+		$isUpdated = $query->update(self::TABLE_GROUPS)
 			->set('displayname', $query->createNamedParameter($displayName))
-			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)));
-		$query->execute();
+			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)))
+			->executeStatement() > 0;
 
-		$this->groupCache[$gid] = $displayName;
+		if ($isUpdated) {
+			$this->groupCache[$gid] = $displayName;
+		}
 
-		return true;
+		return $isUpdated;
 	}
 }

--- a/lib/GroupBackend.php
+++ b/lib/GroupBackend.php
@@ -309,8 +309,8 @@ class GroupBackend extends ABackend implements IAddToGroupBackend, ICountUsersBa
 			->set('displayname', $query->createNamedParameter($displayName))
 			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)));
 		$query->execute();
-        
-        $this->groupCache[$gid] = $displayName;
+
+		$this->groupCache[$gid] = $displayName;
 
 		return true;
 	}

--- a/lib/GroupBackend.php
+++ b/lib/GroupBackend.php
@@ -79,6 +79,9 @@ class GroupBackend extends ABackend implements IAddToGroupBackend, ICountUsersBa
 			$query->where($query->expr()->iLike('gid', $query->createNamedParameter(
 				'%' . $this->dbc->escapeLikeParameter($search) . '%'
 			)));
+			$query->orWhere($query->expr()->iLike('displayname', $query->createNamedParameter(
+				'%' . $this->dbc->escapeLikeParameter($search) . '%'
+			))); 
 		}
 
 		if ((int)$limit > 0) {


### PR DESCRIPTION
SAML's GroupBackend does not allow you to set the display name of the groups.

The Nextcloud interface, ISetDisplayNameBackend, is implemented, which will enable setting the group name to work with SAML.

Also, group searching (on GroupBackend, getGroups method) also searches in display names.