### PR TITLE
ci: switch to any github runner again

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
               - 'composer.lock'
 
   integration:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
We had to run integration tests on github runners, as executing on the local ones was unstable some time ago. I understand issues where resolved with local runners, so we can re-enable them again.

* [x] :warning:  drop the debug commit before merging :warning: 