### PR TITLE
fix: Fire UserChangedEvent only after change happenned

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -572,8 +572,8 @@ class UserBackend extends ABackend implements IApacheBackend, IUserBackend, IGet
 			$currentDisplayname = $this->getDisplayName($uid);
 			if ($newDisplayname !== null
 				&& $currentDisplayname !== $newDisplayname) {
-				$this->eventDispatcher->dispatchTyped(new UserChangedEvent($user, 'displayName', $newDisplayname, $currentDisplayname));
 				$this->setDisplayName($uid, $newDisplayname);
+				$this->eventDispatcher->dispatchTyped(new UserChangedEvent($user, 'displayName', $newDisplayname, $currentDisplayname));
 			}
 
 			if ($newQuota !== null) {


### PR DESCRIPTION
This is not a before event, so the user should already have been changed
 when it fires. Should fix issues with dav address book and newly mapped
 saml users.