### PR TITLE
fix(Groups): drop groups with mixed users from transition list

### DIFF
--- a/lib/Jobs/MigrateGroups.php
+++ b/lib/Jobs/MigrateGroups.php
@@ -66,27 +66,10 @@ class MigrateGroups extends QueuedJob {
 			$candidates = $this->getMigratableGroups();
 			$toMigrate = $this->getGroupsToMigrate($argument['gids'], $candidates);
 			$migrated = $this->migrateGroups($toMigrate);
-			$this->updateCandidatePool($migrated);
+			$this->ownGroupManager->updateCandidatePool($migrated);
 		} catch (\RuntimeException $e) {
 			return;
 		}
-	}
-
-	protected function updateCandidatePool(array $migratedGroups): void {
-		$candidateInfo = $this->config->getAppValue('user_saml', GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION, '');
-		if ($candidateInfo === '' || $candidateInfo === GroupManager::STATE_MIGRATION_PHASE_EXPIRED) {
-			return;
-		}
-		$candidateInfo = \json_decode($candidateInfo, true);
-		if (!isset($candidateInfo['dropAfter']) || !isset($candidateInfo['groups'])) {
-			return;
-		}
-		$candidateInfo['groups'] = array_diff($candidateInfo['groups'], $migratedGroups);
-		$this->config->setAppValue(
-			'user_saml',
-			GroupManager::LOCAL_GROUPS_CHECK_FOR_MIGRATION,
-			json_encode($candidateInfo)
-		);
 	}
 
 	protected function migrateGroups(array $toMigrate): array {

--- a/tests/integration/features/Shibboleth.feature
+++ b/tests/integration/features/Shibboleth.feature
@@ -420,6 +420,7 @@ Feature: Shibboleth
     Then the group backend of "Mixed Bag Of Sweets" should be "Database"
     And Then the group backend of "Mixed Bag Of Sweets" must not be "user_saml"
     And The user value "groups" should be "Mixed Bag Of Sweets,SAML_Astrophysics,SAML_Students"
+    And The setting "localGroupsCheckForMigration" is currently '{"dropAfter":9223372036854775807,"groups":["Astrophysics","Students"]}'
 
   Scenario: Not migrating a group with only SAML members that is not in the migration list
     Given The setting "type" is set to "saml"

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -101,12 +101,8 @@ class FeatureContext implements Context {
 
 	/**
 	 * @Given The setting :settingName is set to :value
-	 *
-	 * @param string $settingName
-	 * @param string $value
 	 */
-	public function theSettingIsSetTo($settingName,
-		$value) {
+	public function theSettingIsSetTo(string $settingName, string $value): void {
 		if (in_array($settingName, [
 			'type',
 			'general-require_provisioned_account',
@@ -136,6 +132,44 @@ class FeatureContext implements Context {
 				1
 			)
 		);
+	}
+
+	/**
+	 * @Then The setting :settingName is currently :expectedValue
+	 */
+	public function theSettingIsCurrently(string $settingName, string $expectedValue): void {
+		if (in_array($settingName, [
+			'type',
+			'general-require_provisioned_account',
+			'general-allow_multiple_user_back_ends',
+			'localGroupsCheckForMigration',
+		])) {
+			$this->changedSettings[] = $settingName;
+			$value = shell_exec(
+				sprintf(
+					'%s %s config:app:get user_saml %s',
+					PHP_BINARY,
+					__DIR__ . '/../../../../../../occ',
+					$settingName
+				)
+			);
+		} else {
+			$value = shell_exec(
+				sprintf(
+					'%s %s saml:config:set --"%s" %d',
+					PHP_BINARY,
+					__DIR__ . '/../../../../../../occ',
+					$settingName,
+					1
+				)
+			);
+		}
+		$value = rtrim($value); // remove trailing newline from shell output
+		if ($value !== $expectedValue) {
+			throw new UnexpectedValueException(
+				sprintf('Config value for %s is %s, but expected was %s', $settingName, $value, $expectedValue)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
this avoids testing one group all over again and again, which might be costly when large groups have to be tested (user facing request!).