### PR TITLE
fix(command): Ensure that writeln() argument is string

### DIFF
--- a/lib/Command/ConfigCreate.php
+++ b/lib/Command/ConfigCreate.php
@@ -26,7 +26,7 @@ class ConfigCreate extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$output->writeln($this->samlSettings->getNewProviderId());
+		$output->writeln((string)$this->samlSettings->getNewProviderId());
 		return 0;
 	}
 }


### PR DESCRIPTION
- Otherwise breaks with https://github.com/nextcloud/3rdparty/pull/1956
- So should be backported to stable30