### PR TITLE
fix(Controller): make redirectUrl optional

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -539,7 +539,7 @@ class SAMLController extends Controller {
 	 * @NoCSRFRequired
 	 * @OnlyUnauthenticatedUsers
 	 */
-	public function selectUserBackEnd(string $redirectUrl): Http\TemplateResponse {
+	public function selectUserBackEnd(string $redirectUrl = ''): Http\TemplateResponse {
 		$attributes = ['loginUrls' => []];
 
 		if ($this->samlSettings->allowMultipleUserBackEnds()) {


### PR DESCRIPTION
… so that calling it does not break when doing it manually and the redirect parameter is lost.

The empty string is also the fallback if it the redirect target was not specified in normal operations.