### PR TITLE
Handle LoginException when authenticating with Apache

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use OC\User\LoginException;
 use OCA\User_SAML\GroupBackend;
 use OCA\User_SAML\SAMLSettings;
 use OCA\User_SAML\UserBackend;
@@ -63,7 +64,21 @@ if ($type === 'environment-variable') {
 		return;
 	}
 
-	OC_User::handleApacheAuth();
+	try {
+		OC_User::handleApacheAuth();
+	} catch (LoginException $e) {
+		if ($request->getPathInfo() === '/apps/user_saml/saml/error') {
+			return;
+		}
+		$targetUrl = $urlGenerator->linkToRouteAbsolute(
+			'user_saml.SAML.genericError',
+			[
+				'message' => $e->getMessage()
+			]
+		);
+		header('Location: ' . $targetUrl);
+		exit();
+	}
 }
 
 if ($returnScript === true) {

--- a/tests/integration/features/EnvironmentVariable.feature
+++ b/tests/integration/features/EnvironmentVariable.feature
@@ -27,3 +27,13 @@ Feature: EnvironmentVariable
     And The environment variable "REMOTE_USER" is set to "certainly-not-provisioned-user"
     When I send a GET request to "http://localhost:8080/index.php/login"
     Then I should be redirected to "http://localhost:8080/index.php/apps/user_saml/saml/notProvisioned"
+
+  Scenario: Authenticating using environment variable with SSO as a disabled user on backend
+    Given A local user with uid "provisioned-disabled-user" exists
+    And A local user with uid "provisioned-disabled-user" is disabled
+    And The setting "type" is set to "environment-variable"
+    And The setting "general-require_provisioned_account" is set to "1"
+    And The setting "general-uid_mapping" is set to "REMOTE_USER"
+    And The environment variable "REMOTE_USER" is set to "provisioned-disabled-user"
+    When I send a GET request to "http://localhost:8080/index.php/login"
+    Then I should be redirected to "http://localhost:8080/index.php/apps/user_saml/saml/error"

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -494,6 +494,21 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @Given A local user with uid :uid is disabled
+	 * @param string $uid
+	 */
+	public function aLocalUserWithUidIsDisabled($uid) {
+		shell_exec(
+			sprintf(
+				'OC_PASS=password %s %s user:disable %s',
+				PHP_BINARY,
+				__DIR__ . '/../../../../../../occ',
+				$uid
+			)
+		);
+	}
+
+	/**
 	 * @Then I hack :uid into existence
 	 */
 	public function hackUserIntoExistence(string $uid): void {


### PR DESCRIPTION
#549 might be fixed by this, although I am not sure if the problem can happen too when using SAML 2.0 or only when authenticating via environment variable (this pull request only fixes it when authenticating via environment variable).

[`handleApacheAuth()` can throw a `LoginException` when trying to authenticate as a disabled user](https://github.com/nextcloud/server/blob/12d39e818d25a4faa632cfd5945f7ef6ec8e8d27/lib/private/legacy/OC_User.php#L158-L161) (and it has done it [since Nextcloud 23.0.0, 22.2.1, 21.0.6 and 20.0.14](https://github.com/nextcloud/server/pull/28939)). This needs to be explicitly handled to redirect to an error page, as otherwise the login page will try to be loaded which, in turn, will try to authenticate again and cause an endless loop.

## How to test

- Setup authentication via environment variable
- In a private browser window, login with a user (to ensure that it will appear in Nextcloud user list)
- Close the private window
- Disable the user that just logged in
- In another private browser window, login again as the disabled user

### Result with this pull request

An error page with _Account disabled_ is shown

### Result without this pull request

Infinite loop of redirections
