### PR TITLE
build(release): 6.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 6.4.1
+
+### Fixed
+
+* [Handle LoginException when authenticating with Apache (user_saml#910)](https://github.com/nextcloud/user_saml/pull/910)
+
 ## 6.4.0
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ The following providers are supported and tested at the moment:
 	* Any other provider that authenticates using the environment variable
 
 While theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.]]></description>
-	<version>6.4.0</version>
+	<version>6.4.1</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>User_SAML</namespace>


### PR DESCRIPTION
It is quick after 6.4.0, but it is another fix that got ready just afterwards I released yesterday and we would like to have this shipped until tomorrow. There is no regression in 6.4.0 or anything like this.