### PR TITLE
fix(UI): set value to the require_provisioned_account option also in env mode

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -175,13 +175,14 @@ class Admin implements ISettings {
 		}
 
 		$type = $this->config->getAppValue('user_saml', 'type');
+
+		$generalSettings['require_provisioned_account'] = [
+			'text' => $this->l10n->t('Only allow authentication if an account exists on some other backend (e.g. LDAP).', [$this->defaults->getName()]),
+			'type' => 'checkbox',
+			'global' => true,
+			'value' => $this->config->getAppValue('user_saml', 'general-require_provisioned_account', '0')
+		];
 		if ($type === 'saml') {
-			$generalSettings['require_provisioned_account'] = [
-				'text' => $this->l10n->t('Only allow authentication if an account exists on some other backend (e.g. LDAP).', [$this->defaults->getName()]),
-				'type' => 'checkbox',
-				'global' => true,
-				'value' => $this->config->getAppValue('user_saml', 'general-require_provisioned_account', '0')
-			];
 			$generalSettings['idp0_display_name'] = [
 				'text' => $this->l10n->t('Optional display name of the identity provider (default: "SSO & SAML log in")'),
 				'type' => 'line',

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -93,6 +93,7 @@ class AdminTest extends \Test\TestCase {
 				'text' => 'Only allow authentication if an account exists on some other backend (e.g. LDAP).',
 				'type' => 'checkbox',
 				'global' => true,
+				'value' => '0'
 			],
 			'allow_multiple_user_back_ends' => [
 				'text' => $this->l10n->t('Allow the use of multiple user back-ends (e.g. LDAP)'),
@@ -220,10 +221,10 @@ class AdminTest extends \Test\TestCase {
 				2 => 'Provider 2',
 			]);
 		$this->config
-			->expects($this->once())
+			->expects($this->exactly(2)) // 'type' and 'general-require_provisioned_account'
 			->method('getAppValue')
-			->with('user_saml', 'type')
-			->willReturn('');
+			->with('user_saml', $this->anything(), $this->anything())
+			->willReturn($this->returnArgument(2));
 
 		$params = $this->formDataProvider();
 		unset($params['general']['idp0_display_name']);


### PR DESCRIPTION
Fixes the problem, that the option always appeard as disabled on a page reload:

[Screencast_20241205_230835.webm](https://github.com/user-attachments/assets/b4edf03c-f60d-430c-a603-4e8c45e599b7)
