### PR TITLE
feat(settings): optional config option for sp entityId

### DIFF
--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -59,7 +59,7 @@ class SAMLSettings {
 		'saml-attribute-mapping-group_mapping_prefix',
 		'saml-user-filter-reject_groups',
 		'saml-user-filter-require_groups',
-        'sp-entityId',
+		'sp-entityId',
 		'sp-x509cert',
 		'sp-name-id-format',
 		'sp-privateKey',

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -59,6 +59,7 @@ class SAMLSettings {
 		'saml-attribute-mapping-group_mapping_prefix',
 		'saml-user-filter-reject_groups',
 		'saml-user-filter-require_groups',
+        'sp-entityId',
 		'sp-x509cert',
 		'sp-name-id-format',
 		'sp-privateKey',
@@ -141,7 +142,7 @@ class SAMLSettings {
 				// "sloWebServerDecode" is not expected to be passed to the OneLogin class
 			],
 			'sp' => [
-				'entityId' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.getMetadata'),
+				'entityId' => $this->configurations[$idp]['sp-entityId'] ?? $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.getMetadata'),
 				'assertionConsumerService' => [
 					'url' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.assertionConsumerService'),
 				],

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -142,7 +142,9 @@ class SAMLSettings {
 				// "sloWebServerDecode" is not expected to be passed to the OneLogin class
 			],
 			'sp' => [
-				'entityId' => $this->configurations[$idp]['sp-entityId'] ?? $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.getMetadata'),
+				'entityId' => (array_key_exists('sp-entityId', $this->configurations[$idp]) && trim($this->configurations[$idp]['sp-entityId']) != '')
+					? $this->configurations[$idp]['sp-entityId']
+					: $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.getMetadata'),
 				'assertionConsumerService' => [
 					'url' => $this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.assertionConsumerService'),
 				],

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -38,9 +38,22 @@ class Admin implements ISettings {
 			];
 		}
 		$serviceProviderFields = [
-			'x509cert' => $this->l10n->t('X.509 certificate of the Service Provider'),
-			'privateKey' => $this->l10n->t('Private key of the Service Provider'),
-		];
+            'x509cert' => [
+				'text' => $this->l10n->t('X.509 certificate of the Service Provider'),
+				'type' => 'text',
+				'required' => false,
+			],
+			'privateKey' => [
+				'text' => $this->l10n->t('Private key of the Service Provider'),
+				'type' => 'text',
+				'required' => false,
+			],
+			'entityId' => [
+				'text' => $this->l10n->t('Service Provider EntityId (optional)'),
+				'type' => 'line',
+				'required' => false,
+			]
+        ];
 		$securityOfferFields = [
 			'nameIdEncrypted' => $this->l10n->t('Indicates that the nameID of the <samlp:logoutRequest> sent by this SP will be encrypted.'),
 			'authnRequestsSigned' => $this->l10n->t('Indicates whether the <samlp:AuthnRequest> messages sent by this SP will be signed. [Metadata of the SP will offer this info]'),

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -38,7 +38,7 @@ class Admin implements ISettings {
 			];
 		}
 		$serviceProviderFields = [
-            'x509cert' => [
+			'x509cert' => [
 				'text' => $this->l10n->t('X.509 certificate of the Service Provider'),
 				'type' => 'text',
 				'required' => false,
@@ -53,7 +53,7 @@ class Admin implements ISettings {
 				'type' => 'line',
 				'required' => false,
 			]
-        ];
+		];
 		$securityOfferFields = [
 			'nameIdEncrypted' => $this->l10n->t('Indicates that the nameID of the <samlp:logoutRequest> sent by this SP will be encrypted.'),
 			'authnRequestsSigned' => $this->l10n->t('Indicates whether the <samlp:AuthnRequest> messages sent by this SP will be signed. [Metadata of the SP will offer this info]'),

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -126,7 +126,7 @@ if (isset($_['general']['allow_multiple_user_back_ends']['text'])) {
 						<label class="user-saml-standalone-label" for="user-saml-<?php p($key) ?>"><?php p($attribute['text']) ?></label><br/>
 						<?php if ($attribute['type'] === 'line'): ?>
 							<input id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>" value="<?php p($_['config']['sp-' . $key] ?? '') ?>" type="text" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?>/>
-						<? else: ?>
+						<?php else: ?>
 							<textarea id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?>><?php p($_['config']['sp-' . $key] ?? '') ?></textarea>
 						<?php endif; ?>
 					</p>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -121,11 +121,15 @@ if (isset($_['general']['allow_multiple_user_back_ends']['text'])) {
 						} ?> ><?php p($value['label']) ?></option>
 					<?php endforeach; ?>
 				</select>
-				<?php foreach ($_['sp'] as $key => $text): ?>
+				<?php foreach ($_['sp'] as $key => $attribute): ?>
 					<p>
-						<label class="user-saml-standalone-label" for="user-saml-<?php p($key) ?>"><?php p($text) ?></label><br/>
-						<textarea id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>"><?php p($_['config']['sp-' . $key] ?? '') ?></textarea>
-					</p>
+						<label class="user-saml-standalone-label" for="user-saml-<?php p($key) ?>"><?php p($attribute['text']) ?></label><br/>
+                        <?php if ($attribute['type'] === 'line'): ?>
+						    <input id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>" value="<?php p($_['config']['sp-' . $key] ?? '') ?>" type="text" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?>/>
+                        <? else: ?>
+                            <textarea id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?>><?php p($_['config']['sp-' . $key] ?? '') ?></textarea>
+                        <?php endif; ?>
+                    </p>
 				<?php endforeach; ?>
 			</div>
 		</div>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -124,12 +124,12 @@ if (isset($_['general']['allow_multiple_user_back_ends']['text'])) {
 				<?php foreach ($_['sp'] as $key => $attribute): ?>
 					<p>
 						<label class="user-saml-standalone-label" for="user-saml-<?php p($key) ?>"><?php p($attribute['text']) ?></label><br/>
-                        <?php if ($attribute['type'] === 'line'): ?>
-						    <input id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>" value="<?php p($_['config']['sp-' . $key] ?? '') ?>" type="text" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?>/>
-                        <? else: ?>
-                            <textarea id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?>><?php p($_['config']['sp-' . $key] ?? '') ?></textarea>
-                        <?php endif; ?>
-                    </p>
+						<?php if ($attribute['type'] === 'line'): ?>
+							<input id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>" value="<?php p($_['config']['sp-' . $key] ?? '') ?>" type="text" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?>/>
+						<? else: ?>
+							<textarea id="user-saml-<?php p($key) ?>" name="<?php p($key) ?>" <?php if (isset($attribute['required']) && $attribute['required'] === true): ?>class="required"<?php endif;?>><?php p($_['config']['sp-' . $key] ?? '') ?></textarea>
+						<?php endif; ?>
+					</p>
 				<?php endforeach; ?>
 			</div>
 		</div>

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -53,8 +53,21 @@ class AdminTest extends \Test\TestCase {
 			});
 
 		$serviceProviderFields = [
-			'x509cert' => 'X.509 certificate of the Service Provider',
-			'privateKey' => 'Private key of the Service Provider',
+            'x509cert' => [
+				'text' => 'X.509 certificate of the Service Provider',
+				'type' => 'text',
+				'required' => false,
+			],
+			'privateKey' => [
+				'text' => 'Private key of the Service Provider',
+				'type' => 'text',
+				'required' => false,
+			],
+			'entityId' => [
+				'text' => 'Service Provider EntityId (optional)',
+				'type' => 'line',
+				'required' => false,
+			]
 		];
 		$securityOfferFields = [
 			'nameIdEncrypted' => 'Indicates that the nameID of the <samlp:logoutRequest> sent by this SP will be encrypted.',

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -53,7 +53,7 @@ class AdminTest extends \Test\TestCase {
 			});
 
 		$serviceProviderFields = [
-            'x509cert' => [
+			'x509cert' => [
 				'text' => 'X.509 certificate of the Service Provider',
 				'type' => 'text',
 				'required' => false,


### PR DESCRIPTION
Right now the service provider entityId is always generated based on the nextcloud instance URL. At least Keycloak relies on that entityId to resolve the corresponding SAML2 client. This PR introduces a new optional config option to allow the admin to set a different service provider entityId manually. If no manual configuration is done, the current behavior remains as the default.