### PR TITLE
fix(Settings): do not fail badly on unknown keys

### DIFF
--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -197,11 +197,9 @@ class SAMLSettings {
 	 * @throws InvalidArgumentException
 	 */
 	public function set(int $id, array $settings): void {
-		foreach (array_keys($settings) as $configKey) {
-			if (!in_array($configKey, self::IDP_CONFIG_KEYS)) {
-				throw new InvalidArgumentException('Invalid config key');
-			}
-		}
+		$settings = array_filter($settings, static function (string $configKey): bool {
+			return in_array($configKey, self::IDP_CONFIG_KEYS, true);
+		}, ARRAY_FILTER_USE_KEY);
 
 		$this->mapper->set($id, $settings);
 	}


### PR DESCRIPTION
This may happen with left over settings when switching from built-in SAML mode to env-mode, for example.

(Or with some development left overs/temporary unknown keys when switching branches)