### PR TITLE
chore(migration): Port away from deprecated IQueryBuilder::execute

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -106,3 +106,9 @@ path = "tests/integration/vendor/symfony/**"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Fabien Potencier"
 SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = ["tests/stubs/doctrine_dbal_**"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "none"
+SPDX-License-Identifier = "MIT"

--- a/lib/Migration/Version5000Date20211025124248.php
+++ b/lib/Migration/Version5000Date20211025124248.php
@@ -151,7 +151,7 @@ class Version5000Date20211025124248 extends SimpleMigrationStep {
 
 		$deletedRows = $this->deleteQuery
 			->setParameter('cfgKeys', $keys, IQueryBuilder::PARAM_STR_ARRAY)
-			->execute();
+			->executeStatement();
 
 		return $deletedRows > 0;
 	}
@@ -174,7 +174,7 @@ class Version5000Date20211025124248 extends SimpleMigrationStep {
 			->setParameter('configId', $id)
 			->setParameter('displayName', $configData['general-idp0_display_name'] ?? '')
 			->setParameter('configuration', \json_encode($configData, JSON_THROW_ON_ERROR))
-			->execute();
+			->executeStatement();
 
 		return $insertedRows > 0;
 	}
@@ -190,7 +190,7 @@ class Version5000Date20211025124248 extends SimpleMigrationStep {
 		}
 
 		$r = $this->readQuery->setParameter('cfgKeys', $configKeys, IQueryBuilder::PARAM_STR_ARRAY)
-			->execute();
+			->executeQuery();
 
 		while ($row = $r->fetch()) {
 			yield $row;
@@ -216,7 +216,7 @@ class Version5000Date20211025124248 extends SimpleMigrationStep {
 			->where($q->expr()->eq('appid', $q->createNamedParameter('user_saml')))
 			->andWhere($q->expr()->eq('configkey', $q->createNamedParameter('providerIds')));
 
-		$r = $q->execute();
+		$r = $q->executeQuery();
 		$prefixes = $r->fetchOne();
 		if ($prefixes === false) {
 			return [1]; // 1 is the default value for providerIds
@@ -229,6 +229,6 @@ class Version5000Date20211025124248 extends SimpleMigrationStep {
 		$q->delete('appconfig')
 			->where($q->expr()->eq('appid', $q->createNamedParameter('user_saml')))
 			->andWhere($q->expr()->eq('configkey', $q->createNamedParameter('providerIds')))
-			->execute();
+			->executeStatement();
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -15,6 +15,10 @@
 >
 	<stubs>
 		<file name="tests/stub.phpstub" preloadClasses="true"/>
+		<file name="tests/stubs/doctrine_dbal_schema_abstractasset.php" />
+		<file name="tests/stubs/doctrine_dbal_schema_column.php" />
+		<file name="tests/stubs/doctrine_dbal_schema_schema.php" />
+		<file name="tests/stubs/doctrine_dbal_schema_table.php" />
 	</stubs>
     <projectFiles>
         <directory name="lib" />
@@ -31,18 +35,8 @@
 		<DeprecatedConstant errorLevel="info" />
 		<UndefinedClass>
 			<errorLevel type="suppress">
-				<referencedClass name="Doctrine\DBAL\Types\Types"/>
 				<referencedClass name="Symfony\Component\Console\Command\Command"/>
 			</errorLevel>
 		</UndefinedClass>
-		<UndefinedDocblockClass>
-			<errorLevel type="suppress">
-				<referencedClass name="Doctrine\DBAL\Driver\Statement" />
-				<referencedClass name="Doctrine\DBAL\Schema\Schema" />
-				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
-				<referencedClass name="Doctrine\DBAL\Schema\Table" />
-				<referencedClass name="Doctrine\DBAL\Statement" />
-			</errorLevel>
-		</UndefinedDocblockClass>
 	</issueHandlers>
 </psalm>

--- a/tests/stubs/doctrine_dbal_schema_abstractasset.php
+++ b/tests/stubs/doctrine_dbal_schema_abstractasset.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * The abstract asset allows to reset the name of all assets without publishing this to the public userland.
+ *
+ * This encapsulation hack is necessary to keep a consistent state of the database schema. Say we have a list of tables
+ * array($tableName => Table($tableName)); if you want to rename the table, you have to make sure this does not get
+ * recreated during schema migration.
+ */
+abstract class AbstractAsset {
+	/** @var string */
+	protected $_name = '';
+
+	/**
+	 * Namespace of the asset. If none isset the default namespace is assumed.
+	 *
+	 * @var string|null
+	 */
+	protected $_namespace;
+
+	/** @var bool */
+	protected $_quoted = false;
+
+	/**
+	 * Sets the name of this asset.
+	 *
+	 * @param string $name
+	 *
+	 * @return void
+	 */
+	protected function _setName($name) {
+	}
+
+	/**
+	 * Is this asset in the default namespace?
+	 *
+	 * @param string $defaultNamespaceName
+	 *
+	 * @return bool
+	 */
+	public function isInDefaultNamespace($defaultNamespaceName) {
+	}
+
+	/**
+	 * Gets the namespace name of this asset.
+	 *
+	 * If NULL is returned this means the default namespace is used.
+	 *
+	 * @return string|null
+	 */
+	public function getNamespaceName() {
+	}
+
+	/**
+	 * The shortest name is stripped of the default namespace. All other
+	 * namespaced elements are returned as full-qualified names.
+	 *
+	 * @param string|null $defaultNamespaceName
+	 *
+	 * @return string
+	 */
+	public function getShortestName($defaultNamespaceName) {
+	}
+
+	/**
+	 * The normalized name is full-qualified and lower-cased. Lower-casing is
+	 * actually wrong, but we have to do it to keep our sanity. If you are
+	 * using database objects that only differentiate in the casing (FOO vs
+	 * Foo) then you will NOT be able to use Doctrine Schema abstraction.
+	 *
+	 * Every non-namespaced element is prefixed with the default namespace
+	 * name which is passed as argument to this method.
+	 *
+	 * @deprecated Use {@see getNamespaceName()} and {@see getName()} instead.
+	 *
+	 * @param string $defaultNamespaceName
+	 *
+	 * @return string
+	 */
+	public function getFullQualifiedName($defaultNamespaceName) {
+	}
+
+	/**
+	 * Checks if this asset's name is quoted.
+	 *
+	 * @return bool
+	 */
+	public function isQuoted() {
+	}
+
+	/**
+	 * Checks if this identifier is quoted.
+	 *
+	 * @param string $identifier
+	 *
+	 * @return bool
+	 */
+	protected function isIdentifierQuoted($identifier) {
+	}
+
+	/**
+	 * Trim quotes from the identifier.
+	 *
+	 * @param string $identifier
+	 *
+	 * @return string
+	 */
+	protected function trimQuotes($identifier) {
+	}
+
+	/**
+	 * Returns the name of this schema asset.
+	 *
+	 * @return string
+	 */
+	public function getName() {
+	}
+
+	/**
+	 * Gets the quoted representation of this asset but only if it was defined with one. Otherwise
+	 * return the plain unquoted value as inserted.
+	 *
+	 * @return string
+	 */
+	public function getQuotedName(AbstractPlatform $platform) {
+	}
+
+	/**
+	 * Generates an identifier from a list of column names obeying a certain string length.
+	 *
+	 * This is especially important for Oracle, since it does not allow identifiers larger than 30 chars,
+	 * however building idents automatically for foreign keys, composite keys or such can easily create
+	 * very long names.
+	 *
+	 * @param string[] $columnNames
+	 * @param string $prefix
+	 * @param int $maxSize
+	 *
+	 * @return string
+	 */
+	protected function _generateIdentifierName($columnNames, $prefix = '', $maxSize = 30) {
+	}
+}

--- a/tests/stubs/doctrine_dbal_schema_column.php
+++ b/tests/stubs/doctrine_dbal_schema_column.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Object representation of a database column.
+ */
+class Column extends AbstractAsset {
+	/** @var Type */
+	protected $_type;
+
+	/** @var int|null */
+	protected $_length;
+
+	/** @var int */
+	protected $_precision = 10;
+
+	/** @var int */
+	protected $_scale = 0;
+
+	/** @var bool */
+	protected $_unsigned = false;
+
+	/** @var bool */
+	protected $_fixed = false;
+
+	/** @var bool */
+	protected $_notnull = true;
+
+	/** @var mixed */
+	protected $_default;
+
+	/** @var bool */
+	protected $_autoincrement = false;
+
+	/** @var mixed[] */
+	protected $_platformOptions = [];
+
+	/** @var string|null */
+	protected $_columnDefinition;
+
+	/** @var string|null */
+	protected $_comment;
+
+	/**
+	 * @deprecated Use {@link $_platformOptions} instead
+	 *
+	 * @var mixed[]
+	 */
+	protected $_customSchemaOptions = [];
+
+	/**
+	 * Creates a new Column.
+	 *
+	 * @param string $name
+	 * @param mixed[] $options
+	 *
+	 * @throws SchemaException
+	 */
+	public function __construct($name, Type $type, array $options = []) {
+	}
+
+	/**
+	 * @param mixed[] $options
+	 *
+	 * @return Column
+	 *
+	 * @throws SchemaException
+	 */
+	public function setOptions(array $options) {
+	}
+
+	/** @return Column */
+	public function setType(Type $type) {
+	}
+
+	/**
+	 * @param int|null $length
+	 *
+	 * @return Column
+	 */
+	public function setLength($length) {
+	}
+
+	/**
+	 * @param int $precision
+	 *
+	 * @return Column
+	 */
+	public function setPrecision($precision) {
+	}
+
+	/**
+	 * @param int $scale
+	 *
+	 * @return Column
+	 */
+	public function setScale($scale) {
+	}
+
+	/**
+	 * @param bool $unsigned
+	 *
+	 * @return Column
+	 */
+	public function setUnsigned($unsigned) {
+	}
+
+	/**
+	 * @param bool $fixed
+	 *
+	 * @return Column
+	 */
+	public function setFixed($fixed) {
+	}
+
+	/**
+	 * @param bool $notnull
+	 *
+	 * @return Column
+	 */
+	public function setNotnull($notnull) {
+	}
+
+	/**
+	 * @param mixed $default
+	 *
+	 * @return Column
+	 */
+	public function setDefault($default) {
+	}
+
+	/**
+	 * @param mixed[] $platformOptions
+	 *
+	 * @return Column
+	 */
+	public function setPlatformOptions(array $platformOptions) {
+	}
+
+	/**
+	 * @param string $name
+	 * @param mixed $value
+	 *
+	 * @return Column
+	 */
+	public function setPlatformOption($name, $value) {
+	}
+
+	/**
+	 * @param string|null $value
+	 *
+	 * @return Column
+	 */
+	public function setColumnDefinition($value) {
+	}
+
+	/** @return Type */
+	public function getType() {
+	}
+
+	/** @return int|null */
+	public function getLength() {
+	}
+
+	/** @return int */
+	public function getPrecision() {
+	}
+
+	/** @return int */
+	public function getScale() {
+	}
+
+	/** @return bool */
+	public function getUnsigned() {
+	}
+
+	/** @return bool */
+	public function getFixed() {
+	}
+
+	/** @return bool */
+	public function getNotnull() {
+	}
+
+	/** @return mixed */
+	public function getDefault() {
+	}
+
+	/** @return mixed[] */
+	public function getPlatformOptions() {
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function hasPlatformOption($name) {
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return mixed
+	 */
+	public function getPlatformOption($name) {
+	}
+
+	/** @return string|null */
+	public function getColumnDefinition() {
+	}
+
+	/** @return bool */
+	public function getAutoincrement() {
+	}
+
+	/**
+	 * @param bool $flag
+	 *
+	 * @return Column
+	 */
+	public function setAutoincrement($flag) {
+	}
+
+	/**
+	 * @param string|null $comment
+	 *
+	 * @return Column
+	 */
+	public function setComment($comment) {
+	}
+
+	/** @return string|null */
+	public function getComment() {
+	}
+
+	/**
+	 * @deprecated Use {@link setPlatformOption()} instead
+	 *
+	 * @param string $name
+	 * @param mixed $value
+	 *
+	 * @return Column
+	 */
+	public function setCustomSchemaOption($name, $value) {
+	}
+
+	/**
+	 * @deprecated Use {@link hasPlatformOption()} instead
+	 *
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function hasCustomSchemaOption($name) {
+	}
+
+	/**
+	 * @deprecated Use {@link getPlatformOption()} instead
+	 *
+	 * @param string $name
+	 *
+	 * @return mixed
+	 */
+	public function getCustomSchemaOption($name) {
+	}
+
+	/**
+	 * @deprecated Use {@link setPlatformOptions()} instead
+	 *
+	 * @param mixed[] $customSchemaOptions
+	 *
+	 * @return Column
+	 */
+	public function setCustomSchemaOptions(array $customSchemaOptions) {
+	}
+
+	/**
+	 * @deprecated Use {@link getPlatformOptions()} instead
+	 *
+	 * @return mixed[]
+	 */
+	public function getCustomSchemaOptions() {
+	}
+
+	/** @return mixed[] */
+	public function toArray() {
+	}
+}

--- a/tests/stubs/doctrine_dbal_schema_schema.php
+++ b/tests/stubs/doctrine_dbal_schema_schema.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Visitor\Visitor;
+
+/**
+ * Object representation of a database schema.
+ *
+ * Different vendors have very inconsistent naming with regard to the concept
+ * of a "schema". Doctrine understands a schema as the entity that conceptually
+ * wraps a set of database objects such as tables, sequences, indexes and
+ * foreign keys that belong to each other into a namespace. A Doctrine Schema
+ * has nothing to do with the "SCHEMA" defined as in PostgreSQL, it is more
+ * related to the concept of "DATABASE" that exists in MySQL and PostgreSQL.
+ *
+ * Every asset in the doctrine schema has a name. A name consists of either a
+ * namespace.local name pair or just a local unqualified name.
+ *
+ * The abstraction layer that covers a PostgreSQL schema is the namespace of an
+ * database object (asset). A schema can have a name, which will be used as
+ * default namespace for the unqualified database objects that are created in
+ * the schema.
+ *
+ * In the case of MySQL where cross-database queries are allowed this leads to
+ * databases being "misinterpreted" as namespaces. This is intentional, however
+ * the CREATE/DROP SQL visitors will just filter this queries and do not
+ * execute them. Only the queries for the currently connected database are
+ * executed.
+ */
+class Schema extends AbstractAsset {
+	/** @var Table[] */
+	protected $_tables = [];
+
+	/** @var Sequence[] */
+	protected $_sequences = [];
+
+	/** @var SchemaConfig */
+	protected $_schemaConfig;
+
+	/**
+	 * @param Table[] $tables
+	 * @param Sequence[] $sequences
+	 * @param string[] $namespaces
+	 *
+	 * @throws SchemaException
+	 */
+	public function __construct(array $tables = [], array $sequences = [], ?SchemaConfig $schemaConfig = null, array $namespaces = []) {
+	}
+
+	/**
+	 * @deprecated
+	 *
+	 * @return bool
+	 */
+	public function hasExplicitForeignKeyIndexes() {
+	}
+
+	/**
+	 * @return void
+	 *
+	 * @throws SchemaException
+	 */
+	protected function _addTable(Table $table) {
+	}
+
+	/**
+	 * @return void
+	 *
+	 * @throws SchemaException
+	 */
+	protected function _addSequence(Sequence $sequence) {
+	}
+
+	/**
+	 * Returns the namespaces of this schema.
+	 *
+	 * @return string[] A list of namespace names.
+	 */
+	public function getNamespaces() {
+	}
+
+	/**
+	 * Gets all tables of this schema.
+	 *
+	 * @return Table[]
+	 */
+	public function getTables() {
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return Table
+	 *
+	 * @throws SchemaException
+	 */
+	public function getTable($name) {
+	}
+
+	/**
+	 * Does this schema have a namespace with the given name?
+	 *
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function hasNamespace($name) {
+	}
+
+	/**
+	 * Does this schema have a table with the given name?
+	 *
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function hasTable($name) {
+	}
+
+	/**
+	 * Gets all table names, prefixed with a schema name, even the default one if present.
+	 *
+	 * @deprecated Use {@see getTables()} and {@see Table::getName()} instead.
+	 *
+	 * @return string[]
+	 */
+	public function getTableNames() {
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function hasSequence($name) {
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return Sequence
+	 *
+	 * @throws SchemaException
+	 */
+	public function getSequence($name) {
+	}
+
+	/** @return Sequence[] */
+	public function getSequences() {
+	}
+
+	/**
+	 * Creates a new namespace.
+	 *
+	 * @param string $name The name of the namespace to create.
+	 *
+	 * @return Schema This schema instance.
+	 *
+	 * @throws SchemaException
+	 */
+	public function createNamespace($name) {
+	}
+
+	/**
+	 * Creates a new table.
+	 *
+	 * @param string $name
+	 *
+	 * @return Table
+	 *
+	 * @throws SchemaException
+	 */
+	public function createTable($name) {
+	}
+
+	/**
+	 * Renames a table.
+	 *
+	 * @param string $oldName
+	 * @param string $newName
+	 *
+	 * @return Schema
+	 *
+	 * @throws SchemaException
+	 */
+	public function renameTable($oldName, $newName) {
+	}
+
+	/**
+	 * Drops a table from the schema.
+	 *
+	 * @param string $name
+	 *
+	 * @return Schema
+	 *
+	 * @throws SchemaException
+	 */
+	public function dropTable($name) {
+	}
+
+	/**
+	 * Creates a new sequence.
+	 *
+	 * @param string $name
+	 * @param int $allocationSize
+	 * @param int $initialValue
+	 *
+	 * @return Sequence
+	 *
+	 * @throws SchemaException
+	 */
+	public function createSequence($name, $allocationSize = 1, $initialValue = 1) {
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return Schema
+	 */
+	public function dropSequence($name) {
+	}
+
+	/**
+	 * Returns an array of necessary SQL queries to create the schema on the given platform.
+	 *
+	 * @return list<string>
+	 *
+	 * @throws Exception
+	 */
+	public function toSql(AbstractPlatform $platform) {
+	}
+
+	/**
+	 * Return an array of necessary SQL queries to drop the schema on the given platform.
+	 *
+	 * @return list<string>
+	 *
+	 * @throws Exception
+	 */
+	public function toDropSql(AbstractPlatform $platform) {
+	}
+
+	/**
+	 * @deprecated
+	 *
+	 * @return string[]
+	 *
+	 * @throws SchemaException
+	 */
+	public function getMigrateToSql(Schema $toSchema, AbstractPlatform $platform) {
+	}
+
+	/**
+	 * @deprecated
+	 *
+	 * @return string[]
+	 *
+	 * @throws SchemaException
+	 */
+	public function getMigrateFromSql(Schema $fromSchema, AbstractPlatform $platform) {
+	}
+
+	/**
+	 * @deprecated
+	 *
+	 * @return void
+	 */
+	public function visit(Visitor $visitor) {
+	}
+
+	/**
+	 * Cloning a Schema triggers a deep clone of all related assets.
+	 *
+	 * @return void
+	 */
+	public function __clone() {
+	}
+}

--- a/tests/stubs/doctrine_dbal_schema_table.php
+++ b/tests/stubs/doctrine_dbal_schema_table.php
@@ -1,0 +1,462 @@
+<?php
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Visitor\Visitor;
+
+/**
+ * Object Representation of a table.
+ */
+class Table extends AbstractAsset {
+	/** @var Column[] */
+	protected $_columns = [];
+
+	/** @var Index[] */
+	protected $_indexes = [];
+
+	/** @var string|null */
+	protected $_primaryKeyName;
+
+	/** @var UniqueConstraint[] */
+	protected $uniqueConstraints = [];
+
+	/** @var ForeignKeyConstraint[] */
+	protected $_fkConstraints = [];
+
+	/** @var mixed[] */
+	protected $_options = [
+		'create_options' => [],
+	];
+
+	/** @var SchemaConfig|null */
+	protected $_schemaConfig;
+
+	/**
+	 * @param Column[] $columns
+	 * @param Index[] $indexes
+	 * @param UniqueConstraint[] $uniqueConstraints
+	 * @param ForeignKeyConstraint[] $fkConstraints
+	 * @param mixed[] $options
+	 *
+	 * @throws SchemaException
+	 * @throws Exception
+	 */
+	public function __construct(string $name, array $columns = [], array $indexes = [], array $uniqueConstraints = [], array $fkConstraints = [], array $options = []) {
+	}
+
+	/** @return void */
+	public function setSchemaConfig(SchemaConfig $schemaConfig) {
+	}
+
+	/** @return int */
+	protected function _getMaxIdentifierLength() {
+	}
+
+	/**
+	 * Sets the Primary Key.
+	 *
+	 * @param string[] $columnNames
+	 * @param string|false $indexName
+	 *
+	 * @return self
+	 *
+	 * @throws SchemaException
+	 */
+	public function setPrimaryKey(array $columnNames, $indexName = false) {
+	}
+
+	/**
+	 * @param string[] $columnNames
+	 * @param string[] $flags
+	 * @param mixed[] $options
+	 *
+	 * @return self
+	 *
+	 * @throws SchemaException
+	 */
+	public function addIndex(array $columnNames, ?string $indexName = null, array $flags = [], array $options = []) {
+	}
+
+	/**
+	 * @param string[] $columnNames
+	 * @param string[] $flags
+	 * @param mixed[] $options
+	 *
+	 * @return self
+	 */
+	public function addUniqueConstraint(array $columnNames, ?string $indexName = null, array $flags = [], array $options = []): Table {
+	}
+
+	/**
+	 * Drops the primary key from this table.
+	 *
+	 * @return void
+	 *
+	 * @throws SchemaException
+	 */
+	public function dropPrimaryKey() {
+	}
+
+	/**
+	 * Drops an index from this table.
+	 *
+	 * @param string $name The index name.
+	 *
+	 * @return void
+	 *
+	 * @throws SchemaException If the index does not exist.
+	 */
+	public function dropIndex($name) {
+	}
+
+	/**
+	 * @param string[] $columnNames
+	 * @param string|null $indexName
+	 * @param mixed[] $options
+	 *
+	 * @return self
+	 *
+	 * @throws SchemaException
+	 */
+	public function addUniqueIndex(array $columnNames, $indexName = null, array $options = []) {
+	}
+
+	/**
+	 * Renames an index.
+	 *
+	 * @param string $oldName The name of the index to rename from.
+	 * @param string|null $newName The name of the index to rename to.
+	 *                             If null is given, the index name will be auto-generated.
+	 *
+	 * @return self This table instance.
+	 *
+	 * @throws SchemaException If no index exists for the given current name
+	 *                         or if an index with the given new name already exists on this table.
+	 */
+	public function renameIndex($oldName, $newName = null) {
+	}
+
+	/**
+	 * Checks if an index begins in the order of the given columns.
+	 *
+	 * @param string[] $columnNames
+	 *
+	 * @return bool
+	 */
+	public function columnsAreIndexed(array $columnNames) {
+	}
+
+	/**
+	 * @param string $name
+	 * @param string $typeName
+	 * @param mixed[] $options
+	 *
+	 * @return Column
+	 *
+	 * @throws SchemaException
+	 */
+	public function addColumn($name, $typeName, array $options = []) {
+	}
+
+	/**
+	 * Change Column Details.
+	 *
+	 * @deprecated Use {@link modifyColumn()} instead.
+	 *
+	 * @param string $name
+	 * @param mixed[] $options
+	 *
+	 * @return self
+	 *
+	 * @throws SchemaException
+	 */
+	public function changeColumn($name, array $options) {
+	}
+
+	/**
+	 * @param string $name
+	 * @param mixed[] $options
+	 *
+	 * @return self
+	 *
+	 * @throws SchemaException
+	 */
+	public function modifyColumn($name, array $options) {
+	}
+
+	/**
+	 * Drops a Column from the Table.
+	 *
+	 * @param string $name
+	 *
+	 * @return self
+	 */
+	public function dropColumn($name) {
+	}
+
+	/**
+	 * Adds a foreign key constraint.
+	 *
+	 * Name is inferred from the local columns.
+	 *
+	 * @param Table|string $foreignTable Table schema instance or table name
+	 * @param string[] $localColumnNames
+	 * @param string[] $foreignColumnNames
+	 * @param mixed[] $options
+	 * @param string|null $name
+	 *
+	 * @return self
+	 *
+	 * @throws SchemaException
+	 */
+	public function addForeignKeyConstraint($foreignTable, array $localColumnNames, array $foreignColumnNames, array $options = [], $name = null) {
+	}
+
+	/**
+	 * @param string $name
+	 * @param mixed $value
+	 *
+	 * @return self
+	 */
+	public function addOption($name, $value) {
+	}
+
+	/**
+	 * @return void
+	 *
+	 * @throws SchemaException
+	 */
+	protected function _addColumn(Column $column) {
+	}
+
+	/**
+	 * Adds an index to the table.
+	 *
+	 * @return self
+	 *
+	 * @throws SchemaException
+	 */
+	protected function _addIndex(Index $indexCandidate) {
+	}
+
+	/** @return self */
+	protected function _addUniqueConstraint(UniqueConstraint $constraint): Table {
+	}
+
+	/** @return self */
+	protected function _addForeignKeyConstraint(ForeignKeyConstraint $constraint) {
+	}
+
+	/**
+	 * Returns whether this table has a foreign key constraint with the given name.
+	 *
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function hasForeignKey($name) {
+	}
+
+	/**
+	 * Returns the foreign key constraint with the given name.
+	 *
+	 * @param string $name The constraint name.
+	 *
+	 * @return ForeignKeyConstraint
+	 *
+	 * @throws SchemaException If the foreign key does not exist.
+	 */
+	public function getForeignKey($name) {
+	}
+
+	/**
+	 * Removes the foreign key constraint with the given name.
+	 *
+	 * @param string $name The constraint name.
+	 *
+	 * @return void
+	 *
+	 * @throws SchemaException
+	 */
+	public function removeForeignKey($name) {
+	}
+
+	/**
+	 * Returns whether this table has a unique constraint with the given name.
+	 */
+	public function hasUniqueConstraint(string $name): bool {
+	}
+
+	/**
+	 * Returns the unique constraint with the given name.
+	 *
+	 * @throws SchemaException If the unique constraint does not exist.
+	 */
+	public function getUniqueConstraint(string $name): UniqueConstraint {
+	}
+
+	/**
+	 * Removes the unique constraint with the given name.
+	 *
+	 * @throws SchemaException If the unique constraint does not exist.
+	 */
+	public function removeUniqueConstraint(string $name): void {
+	}
+
+	/**
+	 * Returns ordered list of columns (primary keys are first, then foreign keys, then the rest)
+	 *
+	 * @return Column[]
+	 */
+	public function getColumns() {
+	}
+
+	/**
+	 * Returns the foreign key columns
+	 *
+	 * @deprecated Use {@see getForeignKey()} and {@see ForeignKeyConstraint::getLocalColumns()} instead.
+	 *
+	 * @return Column[]
+	 */
+	public function getForeignKeyColumns() {
+	}
+
+	/**
+	 * Returns whether this table has a Column with the given name.
+	 *
+	 * @param string $name The column name.
+	 *
+	 * @return bool
+	 */
+	public function hasColumn($name) {
+	}
+
+	/**
+	 * Returns the Column with the given name.
+	 *
+	 * @param string $name The column name.
+	 *
+	 * @return Column
+	 *
+	 * @throws SchemaException If the column does not exist.
+	 */
+	public function getColumn($name) {
+	}
+
+	/**
+	 * Returns the primary key.
+	 *
+	 * @return Index|null The primary key, or null if this Table has no primary key.
+	 */
+	public function getPrimaryKey() {
+	}
+
+	/**
+	 * Returns the primary key columns.
+	 *
+	 * @deprecated Use {@see getPrimaryKey()} and {@see Index::getColumns()} instead.
+	 *
+	 * @return Column[]
+	 *
+	 * @throws Exception
+	 */
+	public function getPrimaryKeyColumns() {
+	}
+
+	/**
+	 * Returns whether this table has a primary key.
+	 *
+	 * @deprecated Use {@see getPrimaryKey()} instead.
+	 *
+	 * @return bool
+	 */
+	public function hasPrimaryKey() {
+	}
+
+	/**
+	 * Returns whether this table has an Index with the given name.
+	 *
+	 * @param string $name The index name.
+	 *
+	 * @return bool
+	 */
+	public function hasIndex($name) {
+	}
+
+	/**
+	 * Returns the Index with the given name.
+	 *
+	 * @param string $name The index name.
+	 *
+	 * @return Index
+	 *
+	 * @throws SchemaException If the index does not exist.
+	 */
+	public function getIndex($name) {
+	}
+
+	/** @return Index[] */
+	public function getIndexes() {
+	}
+
+	/**
+	 * Returns the unique constraints.
+	 *
+	 * @return UniqueConstraint[]
+	 */
+	public function getUniqueConstraints(): array {
+	}
+
+	/**
+	 * Returns the foreign key constraints.
+	 *
+	 * @return ForeignKeyConstraint[]
+	 */
+	public function getForeignKeys() {
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function hasOption($name) {
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return mixed
+	 */
+	public function getOption($name) {
+	}
+
+	/** @return mixed[] */
+	public function getOptions() {
+	}
+
+	/**
+	 * @deprecated
+	 *
+	 * @return void
+	 *
+	 * @throws SchemaException
+	 */
+	public function visit(Visitor $visitor) {
+	}
+
+	/**
+	 * Clone of a Table triggers a deep clone of all affected assets.
+	 *
+	 * @return void
+	 */
+	public function __clone() {
+	}
+
+	public function setComment(?string $comment): self {
+	}
+
+	public function getComment(): ?string {
+	}
+}


### PR DESCRIPTION
And make sures psalm works correctly in the Migration files by providing stubds for the DBAL Schema classes.