### PR TITLE
fix(LDAP): lookup of AD users through objectGUID

### DIFF
--- a/lib/UserData.php
+++ b/lib/UserData.php
@@ -48,9 +48,9 @@ class UserData {
 		}
 		$this->assertIsInitialized();
 		try {
-			$uid = $this->extractSamlUserId();
-			$uid = $this->testEncodedObjectGUID($uid);
-			$uid = $this->userResolver->findExistingUserId($uid, true);
+			$providedUid = $this->extractSamlUserId();
+			$uid = $this->testEncodedObjectGUID($providedUid);
+			$uid = $this->userResolver->findExistingUserId($uid, true, $providedUid !== $uid);
 			$this->uid = $uid;
 		} catch (NoUserFoundException) {
 			return '';


### PR DESCRIPTION
when the objectguid is used in the search, it has to be encoded in a specific way. LDAP does it already, their implemengtation (\OCA\User_LDAP\Access::formatGuid2ForFilterUser) is taken over for now and the generated value passed to search. 

Also for comparison, usage in the LDAP backend: https://github.com/nextcloud/server/blob/5981b7eb512aa411f51cad541d01c5c6e93476f0/apps/user_ldap/lib/Access.php#L1653-L1659

In the longer run, the LDAP API from Nextcloud should provide something, to avoid code duplication, but until that we copy the logic.