### PR TITLE
fix(settings): Fix missing global attribute

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -206,6 +206,7 @@ class Admin implements ISettings {
 				'text' => $this->l10n->t('Use POST method for SAML request (default: GET)'),
 				'type' => 'checkbox',
 				'required' => false,
+				'global' => false,
 			];
 			$generalSettings['allow_multiple_user_back_ends'] = [
 				'text' => $this->l10n->t('Allow the use of multiple user back-ends (e.g. LDAP)'),

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -100,6 +100,7 @@ class AdminTest extends \Test\TestCase {
 				'text' => $this->l10n->t('Use POST method for SAML request (default: GET)'),
 				'type' => 'checkbox',
 				'required' => false,
+				'global' => false,
 			],
 			'uid_mapping' => [
 				'text' => 'Attribute to map the UID to.',


### PR DESCRIPTION
Fix the following error:

Undefined array key "global" in user_saml/templates/admin.php

Fix #991