### PR TITLE
Revert "feat(deps): Add Nextcloud 34 support"

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ The following providers are supported and tested at the moment:
 	* Any other provider that authenticates using the environment variable
 
 While theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.]]></description>
-	<version>7.2.0-dev.0</version>
+	<version>7.1.2</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>User_SAML</namespace>
@@ -37,7 +37,7 @@ While theoretically any other authentication provider implementing either one of
 	<screenshot>https://raw.githubusercontent.com/nextcloud/user_saml/master/screenshots/1.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/user_saml/master/screenshots/2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="30" max-version="34" />
+		<nextcloud min-version="30" max-version="33" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\User_SAML\Jobs\CleanSessionData</job>


### PR DESCRIPTION
This reverts commit 7e587e884d4bf0fa00e33a041191aa5244abd0fb.

To trigger another release on 7.1.x level, don't want to advertise compatibility yet.

Server-Master tests might fail, but can be ignored.

To be re-applied afterwards.