### PR TITLE
feat(settings): implement admin delegation for SSO & SAML authentication

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -10,6 +10,7 @@ namespace OCA\User_SAML\Controller;
 use OCA\User_SAML\SAMLSettings;
 use OCA\User_SAML\Settings\Admin;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IConfig;
@@ -28,6 +29,7 @@ class SettingsController extends Controller {
 		parent::__construct($appName, $request);
 	}
 
+	#[AuthorizedAdminSetting(Admin::class)]
 	public function getSamlProviderIds(): DataResponse {
 		$keys = array_keys($this->samlSettings->getListOfIdps());
 		return new DataResponse([ 'providerIds' => implode(',', $keys)]);
@@ -36,6 +38,7 @@ class SettingsController extends Controller {
 	/**
 	 * @return array of categories containing entries for each config parameter with their value
 	 */
+	#[AuthorizedAdminSetting(Admin::class)]
 	public function getSamlProviderSettings(int $providerId): array {
 		/**
 		 * This uses the list of available config parameters from the admin section
@@ -90,11 +93,13 @@ class SettingsController extends Controller {
 		return $settings;
 	}
 
+	#[AuthorizedAdminSetting(Admin::class)]
 	public function deleteSamlProviderSettings($providerId): Response {
 		$this->samlSettings->delete($providerId);
 		return new Response();
 	}
 
+	#[AuthorizedAdminSetting(Admin::class)]
 	public function setProviderSetting(int $providerId, string $configKey, string $configValue): Response {
 		$configuration = $this->samlSettings->get($providerId);
 		$configuration[$configKey] = $configValue;
@@ -102,6 +107,7 @@ class SettingsController extends Controller {
 		return new Response();
 	}
 
+	#[AuthorizedAdminSetting(Admin::class)]
 	public function newSamlProviderSettingsId(): DataResponse {
 		return new DataResponse(['id' => $this->samlSettings->getNewProviderId()]);
 	}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -12,10 +12,10 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\Settings\ISettings;
+use OCP\Settings\IDelegatedSettings;
 use OneLogin\Saml2\Constants;
 
-class Admin implements ISettings {
+class Admin implements IDelegatedSettings {
 
 	public function __construct(
 		private readonly IL10N $l10n,
@@ -253,5 +253,15 @@ class Admin implements ISettings {
 	#[\Override]
 	public function getPriority() {
 		return 0;
+	}
+
+	#[\Override]
+	public function getName(): ?string {
+		return $this->l10n->t('SSO & SAML authentication');
+	}
+
+	#[\Override]
+	public function getAuthorizedAppConfig(): array {
+		return [];
 	}
 }

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -262,6 +262,13 @@ class Admin implements IDelegatedSettings {
 
 	#[\Override]
 	public function getAuthorizedAppConfig(): array {
-		return [];
+		return [
+			'user_saml' => [
+				'type',
+				'general-require_provisioned_account',
+				'general-allow_multiple_user_back_ends',
+				'directLoginName',
+			],
+		];
 	}
 }

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -17,16 +19,11 @@ use OneLogin\Saml2\Constants;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class AdminTest extends \Test\TestCase {
-	/** @var SAMLSettings|MockObject */
-	private $settings;
-	/** @var Admin */
-	private $admin;
-	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
-	private $l10n;
-	/** @var Defaults|\PHPUnit_Framework_MockObject_MockObject */
-	private $defaults;
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
-	private $config;
+	private SAMLSettings&MockObject $settings;
+	private Admin $admin;
+	private IL10N&MockObject $l10n;
+	private Defaults&MockObject $defaults;
+	private IConfig&MockObject $config;
 
 	protected function setUp(): void {
 		$this->l10n = $this->createMock(IL10N::class);
@@ -288,5 +285,23 @@ class AdminTest extends \Test\TestCase {
 
 	public function testGetPriority() {
 		$this->assertSame(0, $this->admin->getPriority());
+	}
+
+	public function testGetName(): void {
+		$this->l10n->expects($this->once())
+			->method('t')
+			->with('SSO & SAML authentication')
+			->willReturn('SSO & SAML authentication');
+
+		$this->assertSame('SSO & SAML authentication', $this->admin->getName());
+	}
+
+	public function testGetAuthorizedAppConfig(): void {
+		$this->assertSame([], $this->admin->getAuthorizedAppConfig());
+	}
+
+	public function testImplementsIDelegatedSettings(): void {
+		$this->assertInstanceOf(\OCP\Settings\IDelegatedSettings::class, $this->admin);
+		$this->assertInstanceOf(\OCP\Settings\ISettings::class, $this->admin);
 	}
 }

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -297,7 +297,15 @@ class AdminTest extends \Test\TestCase {
 	}
 
 	public function testGetAuthorizedAppConfig(): void {
-		$this->assertSame([], $this->admin->getAuthorizedAppConfig());
+		$config = $this->admin->getAuthorizedAppConfig();
+
+		$this->assertArrayHasKey('user_saml', $config);
+
+		$keys = $config['user_saml'];
+		$this->assertContains('type', $keys);
+		$this->assertContains('general-require_provisioned_account', $keys);
+		$this->assertContains('general-allow_multiple_user_back_ends', $keys);
+		$this->assertContains('directLoginName', $keys);
 	}
 
 	public function testImplementsIDelegatedSettings(): void {


### PR DESCRIPTION
## Summary

- Implement `IDelegatedSettings` in the `Admin` settings class, adding
  `getName()` and `getAuthorizedAppConfig()` with the global config keys
  required for delegated access (`type`, `general-require_provisioned_account`,
  `general-allow_multiple_user_back_ends`, `directLoginName`)
- Add `#[AuthorizedAdminSetting(Admin::class)]` to all `SettingsController`
  read and write methods so delegated admins can fully load and save settings

## Why

`IDelegatedSettings` allows Nextcloud admins to grant non-admin users access
to the SSO & SAML settings panel without giving them full admin rights.

## Test plan

- [ ] Unit tests pass: `composer run test:unit`
- [ ] Code style: `composer run cs:fix` (no changes expected)
- [ ] Manually verify a delegated admin can open and save SSO & SAML settings