### PR TITLE
fix: Use correct color for login screen text on dark background

### DIFF
--- a/css/selectUserBackEnd.css
+++ b/css/selectUserBackEnd.css
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 #saml-select-user-back-end {
-	color: var(--color-primary-text);
+	color: var(--color-background-plain-text);
 }
 
 #saml-select-user-back-end #av_mode {


### PR DESCRIPTION
I was not able to test the change.