### PR TITLE
feat: Trigged UserLoggedInEvent when user log in

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -38,6 +39,7 @@ use OCP\IUserSession;
 use OCP\Security\ICrypto;
 use OCP\Security\ITrustedDomainHelper;
 use OCP\Server;
+use OCP\User\Events\UserLoggedInEvent;
 use OneLogin\Saml2\Auth;
 use OneLogin\Saml2\Error;
 use OneLogin\Saml2\Settings;
@@ -66,6 +68,7 @@ class SAMLController extends Controller {
 		private ICrypto $crypto,
 		private ITrustedDomainHelper $trustedDomainHelper,
 		private SessionService $sessionService,
+		private IEventDispatcher $eventDispatcher,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -402,6 +405,7 @@ class SAMLController extends Controller {
 			if ($firstLogin) {
 				$this->userBackend->initializeHomeDir($user->getUID());
 			}
+			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $user->getUID(), null, false));
 		} catch (NoUserFoundException) {
 			throw new \InvalidArgumentException('User "' . $this->userBackend->getCurrentUserId() . '" is not valid');
 		} catch (Exception $e) {

--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -38,6 +39,7 @@ use OCP\IUserSession;
 use OCP\Security\ICrypto;
 use OCP\Security\ITrustedDomainHelper;
 use OCP\Server;
+use OCP\User\Events\UserLoggedInEvent;
 use OneLogin\Saml2\Auth;
 use OneLogin\Saml2\Error;
 use OneLogin\Saml2\Settings;
@@ -66,6 +68,7 @@ class SAMLController extends Controller {
 		private ICrypto $crypto,
 		private ITrustedDomainHelper $trustedDomainHelper,
 		private SessionService $sessionService,
+		private IEventDispatcher $eventDispatcher,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -392,6 +395,7 @@ class SAMLController extends Controller {
 			if ($firstLogin) {
 				$this->userBackend->initializeHomeDir($user->getUID());
 			}
+			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $user->getUID(), null, true));
 		} catch (NoUserFoundException $e) {
 			throw new \InvalidArgumentException('User "' . $this->userBackend->getCurrentUserId() . '" is not valid.', previous: $e);
 		} catch (Exception $e) {

--- a/tests/unit/Controller/SAMLControllerTest.php
+++ b/tests/unit/Controller/SAMLControllerTest.php
@@ -19,6 +19,7 @@ use OCA\User_SAML\UserResolver;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -28,6 +29,7 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Security\ICrypto;
 use OCP\Security\ITrustedDomainHelper;
+use OCP\User\Events\UserLoggedInEvent;
 use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -49,8 +51,9 @@ class SAMLControllerTest extends TestCase {
 	private IL10N&MockObject $l;
 	private ICrypto&MockObject $crypto;
 	private SAMLController $samlController;
-	private ITrustedDomainHelper|MockObject $trustedDomainController;
-	private SessionService|MockObject $sessionService;
+	private ITrustedDomainHelper&MockObject $trustedDomainController;
+	private SessionService&MockObject $sessionService;
+	private IEventDispatcher&MockObject $eventDispatcher;
 
 	#[Override]
 	protected function setUp(): void {
@@ -71,6 +74,7 @@ class SAMLControllerTest extends TestCase {
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->trustedDomainController = $this->createMock(ITrustedDomainHelper::class);
 		$this->sessionService = $this->createMock(SessionService::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 
 		$this->l->expects($this->any())->method('t')->willReturnCallback(
 			static fn (string $param): string => $param
@@ -95,7 +99,8 @@ class SAMLControllerTest extends TestCase {
 			$this->userData,
 			$this->crypto,
 			$this->trustedDomainController,
-			$this->sessionService
+			$this->sessionService,
+			$this->eventDispatcher,
 		);
 	}
 
@@ -263,6 +268,7 @@ class SAMLControllerTest extends TestCase {
 
 		if (isset($samlUserData['uid']) && !($userState === 0 && $autoProvision === 0)) {
 			$user = $this->createMock(IUser::class);
+			$user->method('getUID')->willReturn('MyUid');
 			$im = $this->userResolver
 				->expects($this->once())
 				->method('findExistingUser')

--- a/tests/unit/Controller/SAMLControllerTest.php
+++ b/tests/unit/Controller/SAMLControllerTest.php
@@ -19,6 +19,7 @@ use OCA\User_SAML\UserResolver;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -49,8 +50,9 @@ class SAMLControllerTest extends TestCase {
 	private IL10N&MockObject $l;
 	private ICrypto&MockObject $crypto;
 	private SAMLController $samlController;
-	private ITrustedDomainHelper|MockObject $trustedDomainController;
-	private SessionService|MockObject $sessionService;
+	private ITrustedDomainHelper&MockObject $trustedDomainController;
+	private SessionService&MockObject $sessionService;
+	private IEventDispatcher&MockObject $eventDispatcher;
 
 	#[Override]
 	protected function setUp(): void {
@@ -71,6 +73,7 @@ class SAMLControllerTest extends TestCase {
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->trustedDomainController = $this->createMock(ITrustedDomainHelper::class);
 		$this->sessionService = $this->createMock(SessionService::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 
 		$this->l->expects($this->any())->method('t')->willReturnCallback(
 			static fn (string $param): string => $param
@@ -95,7 +98,8 @@ class SAMLControllerTest extends TestCase {
 			$this->userData,
 			$this->crypto,
 			$this->trustedDomainController,
-			$this->sessionService
+			$this->sessionService,
+			$this->eventDispatcher,
 		);
 	}
 
@@ -263,6 +267,7 @@ class SAMLControllerTest extends TestCase {
 
 		if (isset($samlUserData['uid']) && !($userState === 0 && $autoProvision === 0)) {
 			$user = $this->createMock(IUser::class);
+			$user->method('getUID')->willReturn('MyUid');
 			$im = $this->userResolver
 				->expects($this->once())
 				->method('findExistingUser')


### PR DESCRIPTION
Took over from #851

We don't need all the events from that merge requests as some of these are already triggered by other methods (e.g. logout event is triggered in `userSession->logout()`)