### PR TITLE
chore: Add back support for 34

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -38,7 +38,7 @@ While theoretically any other authentication provider implementing either one of
 	<screenshot>https://raw.githubusercontent.com/nextcloud/user_saml/master/screenshots/1.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/user_saml/master/screenshots/2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="32" max-version="33" />
+		<nextcloud min-version="32" max-version="34" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\User_SAML\Jobs\CleanSessionData</job>


### PR DESCRIPTION
The supported version was lowered again in:
- https://github.com/nextcloud/user_saml/pull/1077