### PR TITLE
fix: Fix dialog button wording to be more understandable

### DIFF
--- a/src/components/ProviderSettingsDialog.vue
+++ b/src/components/ProviderSettingsDialog.vue
@@ -12,17 +12,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		@update:open="onOpenChanged"
 		@submit="saveAll">
 		<template #actions>
+			<NcButton variant="tertiary" :disabled="!isDirty" @click="cancelChanges">
+				{{ t('user_saml', 'Cancel changes') }}
+			</NcButton>
 			<NcButton
 				variant="secondary"
 				:href="metadataUrl"
 				download>
 				{{ t('user_saml', 'Download metadata XML') }}
 			</NcButton>
-			<NcButton variant="tertiary" :disabled="!isDirty" @click="cancelChanges">
-				{{ t('user_saml', 'Cancel') }}
-			</NcButton>
 			<NcButton variant="primary" type="submit" :disabled="!isDirty || isSaving">
-				{{ isSaving ? t('user_saml', 'Saving…') : t('user_saml', 'Edit') }}
+				{{ isSaving ? t('user_saml', 'Saving changes…') : t('user_saml', 'Save changes') }}
 			</NcButton>
 		</template>
 


### PR DESCRIPTION
Reported by @Cloudboom in design feedback Talk conversation. :) 

- Changed wording of main button from "Edit" to "Save changes". Also makes it more understandable why it is greyed out / disabled by default
- Changed wording of "Cancel" to "Cancel changes" and moved it leftmost, so there is less likelihood of accidentally clicking

Before | After
-|-
<img width="1445" height="1100" alt="Screenshot From 2026-04-30 12-36-55" src="https://github.com/user-attachments/assets/8d68c04b-58f4-43dd-b853-6bc31c9bcd74" />|<img width="1445" height="1100" alt="Screenshot From 2026-04-30 12-36-28" src="https://github.com/user-attachments/assets/79798771-94f8-43ef-a043-36e881ba433d" />
<img width="1445" height="1100" alt="Screenshot From 2026-04-30 12-37-00" src="https://github.com/user-attachments/assets/d99330ce-b715-4370-a4ac-7b208ad5cd20" />|<img width="1445" height="1100" alt="Screenshot From 2026-04-30 12-36-36" src="https://github.com/user-attachments/assets/49532076-0493-4305-9f95-9f0d72056538" />

