### PR TITLE
fix: Mark all mapping attributes as optional

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -121,12 +121,12 @@ class Admin implements IDelegatedSettings {
 			'displayName_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the displayname to.'),
 				'type' => 'line',
-				'required' => true,
+				'required' => false,
 			],
 			'email_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the email address to.'),
 				'type' => 'line',
-				'required' => true,
+				'required' => false,
 			],
 			'quota_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the quota to.'),

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -134,12 +134,12 @@ class AdminTest extends \Test\TestCase {
 			'displayName_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the displayname to.'),
 				'type' => 'line',
-				'required' => true,
+				'required' => false,
 			],
 			'email_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the email address to.'),
 				'type' => 'line',
-				'required' => true,
+				'required' => false,
 			],
 			'quota_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the quota to.'),


### PR DESCRIPTION
Fix #1085 