### PR TITLE
fix: Chunk group migration

### DIFF
--- a/lib/GroupManager.php
+++ b/lib/GroupManager.php
@@ -243,7 +243,9 @@ class GroupManager {
 			return;
 		}
 
-		$this->jobList->add(MigrateGroups::class, ['gids' => $groups]);
+		foreach (array_chunk($groups, 30) as $chunk) {
+			$this->jobList->add(MigrateGroups::class, ['gids' => $chunk]);
+		}
 	}
 
 	protected function isGroupInTransitionList(string $groupId): bool {


### PR DESCRIPTION
Avoid job arguments can't exceed 4000 characters error

Fix #960