### PR TITLE
fix: Handle unique constrainst exception related to the session data

### DIFF
--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -87,7 +87,13 @@ class SessionService {
 		$sessionData->setTokenId($this->tokenProvider->getToken($this->session->getId())->getId());
 		$sessionData->setData($sessionDataModel);
 
-		$this->sessionDataMapper->insert($sessionData);
+		try {
+			$this->sessionDataMapper->insert($sessionData);
+		} catch (Exception $exception) {
+			if ($exception->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				$this->sessionDataMapper->update($sessionData);
+			}
+		}
 	}
 
 	protected function storeSessionDataInSession(SessionData $sessionData): void {


### PR DESCRIPTION
If a session with the same id already exists in the DB, update the entry instead.