### PR TITLE
feat: Flexible matching between LDAP and SAML user ids

### DIFF
--- a/lib/Controller/SAMLController.php
+++ b/lib/Controller/SAMLController.php
@@ -392,8 +392,8 @@ class SAMLController extends Controller {
 			if ($firstLogin) {
 				$this->userBackend->initializeHomeDir($user->getUID());
 			}
-		} catch (NoUserFoundException) {
-			throw new \InvalidArgumentException('User "' . $this->userBackend->getCurrentUserId() . '" is not valid');
+		} catch (NoUserFoundException $e) {
+			throw new \InvalidArgumentException('User "' . $this->userBackend->getCurrentUserId() . '" is not valid.', previous: $e);
 		} catch (Exception $e) {
 			$this->logger->critical($e->getMessage(), ['exception' => $e, 'app' => $this->appName]);
 			$response = new Http\RedirectResponse($this->urlGenerator->linkToRouteAbsolute('user_saml.SAML.notProvisioned'));

--- a/lib/SAMLSettings.php
+++ b/lib/SAMLSettings.php
@@ -59,6 +59,7 @@ class SAMLSettings {
 		'saml-attribute-mapping-home_mapping',
 		'saml-attribute-mapping-quota_mapping',
 		'saml-attribute-mapping-mfa_mapping',
+		'saml-attribute-mapping-user_id_ldap_mapping',
 		'saml-attribute-mapping-group_mapping_prefix',
 		'saml-user-filter-reject_groups',
 		'saml-user-filter-require_groups',

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -24,6 +24,7 @@ class Admin implements IDelegatedSettings {
 		private readonly IL10N $l10n,
 		private readonly Defaults $defaults,
 		private readonly IAppConfig $appConfig,
+		private readonly IConfig $config,
 		private readonly SAMLSettings $samlSettings,
 		private readonly IInitialState $initialState,
 	) {
@@ -148,12 +149,21 @@ class Admin implements IDelegatedSettings {
 				'type' => 'line',
 				'required' => false,
 			],
+			'user_id_ldap_mapping' => [
+				'text' => $this->l10n->t('Attribute to map the users to an existing LDAP user'),
+				'type' => 'line',
+				'required' => false,
+			],
 			'group_mapping_prefix' => [
 				'text' => $this->l10n->t('Group Mapping Prefix, default: %s', [SAMLSettings::DEFAULT_GROUP_PREFIX]),
 				'type' => 'line',
 				'required' => false,
 			],
 		];
+
+		if (version_compare($this->config->getSystemValueString('version', '0.0.0'), '34.0.0', '<')) {
+			unset($attributeMappingSettings['user_id_ldap_mapping']);
+		}
 
 		$userFilterSettings = [
 			'reject_groups' => [

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Defaults;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\Settings\IDelegatedSettings;
 use OneLogin\Saml2\Constants;
@@ -24,6 +25,7 @@ class Admin implements IDelegatedSettings {
 		private readonly IL10N $l10n,
 		private readonly Defaults $defaults,
 		private readonly IAppConfig $appConfig,
+		private readonly IConfig $config,
 		private readonly SAMLSettings $samlSettings,
 		private readonly IInitialState $initialState,
 	) {
@@ -148,12 +150,21 @@ class Admin implements IDelegatedSettings {
 				'type' => 'line',
 				'required' => false,
 			],
+			'user_id_ldap_mapping' => [
+				'text' => $this->l10n->t('Attribute to map the users to an existing LDAP user'),
+				'type' => 'line',
+				'required' => false,
+			],
 			'group_mapping_prefix' => [
 				'text' => $this->l10n->t('Group Mapping Prefix, default: %s', [SAMLSettings::DEFAULT_GROUP_PREFIX]),
 				'type' => 'line',
 				'required' => false,
 			],
 		];
+
+		if (version_compare($this->config->getSystemValueString('version', '0.0.0'), '34.0.0', '<')) {
+			unset($attributeMappingSettings['user_id_ldap_mapping']);
+		}
 
 		$userFilterSettings = [
 			'reject_groups' => [

--- a/lib/UserData.php
+++ b/lib/UserData.php
@@ -49,7 +49,7 @@ class UserData {
 		try {
 			$providedUid = $this->extractSamlUserId();
 			$uid = $this->testEncodedObjectGUID($providedUid);
-			$uid = $this->userResolver->findExistingUserId($uid, true, $providedUid !== $uid);
+			$uid = $this->userResolver->findExistingUserId($uid, $this->getProviderSettings(), true, $providedUid !== $uid);
 			$this->uid = $uid;
 		} catch (NoUserFoundException) {
 			return '';

--- a/lib/UserResolver.php
+++ b/lib/UserResolver.php
@@ -9,19 +9,52 @@ declare(strict_types=1);
 namespace OCA\User_SAML;
 
 use OCA\User_SAML\Exceptions\NoUserFoundException;
+use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\LDAP\Exceptions\MultipleUsersReturnedException;
+use OCP\LDAP\ILDAPProviderFactory;
+use OCP\Server;
 
 class UserResolver {
 	public function __construct(
-		private IUserManager $userManager,
+		private readonly IUserManager $userManager,
+		private readonly ILDAPProviderFactory $ldapProviderFactory,
+		private readonly IConfig $config,
 	) {
 	}
 
 	/**
 	 * @throws NoUserFoundException
 	 */
-	public function findExistingUserId(string $rawUidCandidate, bool $force = false, bool $isActiveDirectory = false): string {
+	public function findExistingUserId(string $rawUidCandidate, ?array $idpSettings = null, bool $force = false, bool $isActiveDirectory = false): string {
+		// If configured, find the user based on a different LDAP attribute.
+		if ($idpSettings !== null
+			&& version_compare($this->config->getSystemValueString('version', '0.0.0'), '34.0.0', '>=')
+			&& $this->ldapProviderFactory->isAvailable()
+			&& isset($idpSettings['saml-attribute-mapping-user_id_ldap_mapping'])
+			&& $idpSettings['saml-attribute-mapping-user_id_ldap_mapping'] !== null
+			&& $idpSettings['saml-attribute-mapping-user_id_ldap_mapping'] !== '') {
+			$userIdLdapMapping = $idpSettings['saml-attribute-mapping-user_id_ldap_mapping'];
+			try {
+				if ($isActiveDirectory) {
+					/** @psalm-suppress UndefinedInterfaceMethod only in NC 34 or above */
+					$user = $this->ldapProviderFactory->getLDAPProvider()->findOneUserByAttributeValue($userIdLdapMapping, $this->formatGuid2ForFilterUser($rawUidCandidate));
+				} else {
+					/** @psalm-suppress UndefinedInterfaceMethod only in NC 34 or above */
+					$user = $this->ldapProviderFactory->getLDAPProvider()->findOneUserByAttributeValue($userIdLdapMapping, $rawUidCandidate);
+				}
+				/** @psalm-suppress UndefinedClass only in NC 34 or above */
+			} catch (MultipleUsersReturnedException $e) {
+				return '';
+			}
+			if ($user !== null) {
+				return $user->getUID();
+			}
+
+			// continue normal workflow
+		}
+
 		if ($force) {
 			if ($isActiveDirectory) {
 				$this->ensureUser($this->formatGuid2ForFilterUser($rawUidCandidate));
@@ -86,14 +119,14 @@ class UserResolver {
 		$uid = $this->findExistingUserId($rawUidCandidate);
 		$user = $this->userManager->get($uid);
 		if ($user === null) {
-			throw new NoUserFoundException('User' . $rawUidCandidate . ' not valid or not found');
+			throw new NoUserFoundException('User ' . $rawUidCandidate . ' not valid or not found.');
 		}
 		return $user;
 	}
 
-	public function userExists(string $uid, bool $force = false): bool {
+	public function userExists(string $uid, array $idpSettings, bool $force = false): bool {
 		try {
-			$this->findExistingUserId($uid, $force);
+			$this->findExistingUserId($uid, $idpSettings, $force);
 			return true;
 		} catch (NoUserFoundException) {
 			return false;

--- a/lib/UserResolver.php
+++ b/lib/UserResolver.php
@@ -9,19 +9,55 @@ declare(strict_types=1);
 namespace OCA\User_SAML;
 
 use OCA\User_SAML\Exceptions\NoUserFoundException;
+use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\LDAP\Exceptions\MultipleUsersReturnedException;
+use OCP\LDAP\ILDAPProviderFactory;
+use OCP\Server;
 
 class UserResolver {
 	public function __construct(
-		private IUserManager $userManager,
+		private readonly IUserManager $userManager,
+		private readonly ILDAPProviderFactory $ldapProviderFactory,
+		private readonly IConfig $config,
 	) {
 	}
 
 	/**
 	 * @throws NoUserFoundException
 	 */
-	public function findExistingUserId(string $rawUidCandidate, bool $force = false, bool $isActiveDirectory = false): string {
+	public function findExistingUserId(string $rawUidCandidate, ?array $idpSettings = null, bool $force = false, bool $isActiveDirectory = false): string {
+		// If configured, find the user based on a different LDAP attribute.
+		if ($idpSettings !== null
+			&& version_compare($this->config->getSystemValueString('version', '0.0.0'), '34.0.0', '>=')
+			&& $this->ldapProviderFactory->isAvailable()
+			&& isset($idpSettings['saml-attribute-mapping-user_id_ldap_mapping'])
+			&& $idpSettings['saml-attribute-mapping-user_id_ldap_mapping'] !== null
+			&& $idpSettings['saml-attribute-mapping-user_id_ldap_mapping'] !== '') {
+			$userIdLdapMapping = $idpSettings['saml-attribute-mapping-user_id_ldap_mapping'];
+			/** @psalm-suppress UndefinedClass only in NC 34 or above */
+			try {
+				if ($isActiveDirectory) {
+					$rawUidCandidate = $this->formatGuid2ForFilterUser($rawUidCandidate);
+				}
+
+				if ($rawUidCandidate === '') {
+					throw new NoUserFoundException('User id is empty');
+				}
+
+				/** @psalm-suppress UndefinedInterfaceMethod only in NC 34 or above */
+				$user = $this->ldapProviderFactory->getLDAPProvider()->findOneUserByAttributeValue($userIdLdapMapping, $rawUidCandidate);
+			} catch (MultipleUsersReturnedException $e) {
+				return '';
+			}
+			if ($user !== null) {
+				return $user->getUID();
+			}
+
+			// continue normal workflow
+		}
+
 		if ($force) {
 			if ($isActiveDirectory) {
 				$this->ensureUser($this->formatGuid2ForFilterUser($rawUidCandidate));
@@ -40,7 +76,7 @@ class UserResolver {
 		if ($this->userManager->userExists($sanitized)) {
 			return $sanitized;
 		}
-		throw new NoUserFoundException('User' . $rawUidCandidate . ' not valid or not found');
+		throw new NoUserFoundException('User ' . $rawUidCandidate . ' not valid or not found');
 	}
 
 	/**
@@ -86,14 +122,14 @@ class UserResolver {
 		$uid = $this->findExistingUserId($rawUidCandidate);
 		$user = $this->userManager->get($uid);
 		if ($user === null) {
-			throw new NoUserFoundException('User' . $rawUidCandidate . ' not valid or not found');
+			throw new NoUserFoundException('User ' . $rawUidCandidate . ' not valid or not found.');
 		}
 		return $user;
 	}
 
-	public function userExists(string $uid, bool $force = false): bool {
+	public function userExists(string $uid, array $idpSettings, bool $force = false): bool {
 		try {
-			$this->findExistingUserId($uid, $force);
+			$this->findExistingUserId($uid, $idpSettings, $force);
 			return true;
 		} catch (NoUserFoundException) {
 			return false;

--- a/tests/unit/Settings/AdminTest.php
+++ b/tests/unit/Settings/AdminTest.php
@@ -15,6 +15,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Defaults;
+use OCP\IConfig;
 use OCP\IL10N;
 use OneLogin\Saml2\Constants;
 use Override;
@@ -26,6 +27,7 @@ class AdminTest extends \Test\TestCase {
 	private IL10N&MockObject $l10n;
 	private Defaults&MockObject $defaults;
 	private IAppConfig&MockObject $appConfig;
+	private IConfig&MockObject $config;
 	private IInitialState&MockObject $initialState;
 
 	#[Override]
@@ -33,6 +35,7 @@ class AdminTest extends \Test\TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->defaults = $this->createMock(Defaults::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->settings = $this->createMock(SAMLSettings::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 
@@ -40,6 +43,7 @@ class AdminTest extends \Test\TestCase {
 			$this->l10n,
 			$this->defaults,
 			$this->appConfig,
+			$this->config,
 			$this->settings,
 			$this->initialState,
 		);
@@ -48,6 +52,9 @@ class AdminTest extends \Test\TestCase {
 	}
 
 	public function formDataProvider(): array {
+		$this->config->method('getSystemValueString')->with('version', '0.0.0')
+			->willReturn('34.0.0');
+
 		$this->l10n
 			->expects($this->any())
 			->method('t')
@@ -158,6 +165,11 @@ class AdminTest extends \Test\TestCase {
 			],
 			'mfa_mapping' => [
 				'text' => $this->l10n->t('Attribute to map the users MFA login status'),
+				'type' => 'line',
+				'required' => false,
+			],
+			'user_id_ldap_mapping' => [
+				'text' => $this->l10n->t('Attribute to map the users to an existing LDAP user'),
 				'type' => 'line',
 				'required' => false,
 			],


### PR DESCRIPTION
Test plan:

1. Setup LDAP with an user `uid=bender mail=bender@planetexpress.com`
2. Setup SAML with an user `uid=bender@planetexpress.com` and attribute to map user to existing LDAP `users = mail`
3. Login with SAML, we will end up with the LDAP user