### PR TITLE
docs: USE SPDX license identified

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ The following providers are supported and tested at the moment:
 
 While theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.]]></description>
 	<version>8.1.1</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Lukas Reschke</author>
 	<namespace>User_SAML</namespace>
 	<types>


### PR DESCRIPTION
given the main branch is 32+ (>31) - we can use the SPDX ID

AGPL-3.0-only are just 2 files in the repo within the tests, hence the app is "-or-later".