### PR TITLE
fix: Update display name in User object

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -541,7 +541,7 @@ class UserBackend extends ABackend implements IApacheBackend, IUserBackend, IGet
 			$currentDisplayname = $this->getDisplayName($uid);
 			if ($newDisplayname !== null
 				&& $currentDisplayname !== $newDisplayname) {
-				$this->setDisplayName($uid, $newDisplayname);
+				$user->setDisplayName($newDisplayname);
 				$this->logger->debug('Display name updated', ['app' => 'user_saml', 'user' => $user->getUID()]);
 				$this->eventDispatcher->dispatchTyped(new UserChangedEvent($user, 'displayName', $newDisplayname, $currentDisplayname));
 				$this->logger->debug('Display name update event dispatched', ['app' => 'user_saml', 'user' => $user->getUID()]);

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -289,10 +289,9 @@ class UserBackendTest extends TestCase {
 			->method('getDisplayName')
 			->with('ExistingUser')
 			->willReturn('');
-		$this->userBackend
-			->expects($this->once())
+		$user->expects($this->once())
 			->method('setDisplayName')
-			->with('ExistingUser', 'New Displayname');
+			->with('New Displayname');
 		$this->groupManager
 			->expects($this->once())
 			->method('handleIncomingGroups')
@@ -343,10 +342,9 @@ class UserBackendTest extends TestCase {
 			->method('getDisplayName')
 			->with('ExistingUser')
 			->willReturn('');
-		$this->userBackend
-			->expects($this->once())
+		$user->expects($this->once())
 			->method('setDisplayName')
-			->with('ExistingUser', 'New Displayname');
+			->with('New Displayname');
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatchTyped')
 			->with(new UserChangedEvent($user, 'displayName', 'New Displayname', ''));


### PR DESCRIPTION
This is breaking other consumers of the user object as they will use the old display name. This was an issue in Talk where they cache the display names.

- Need https://github.com/nextcloud/server/pull/61593