### PR TITLE
fix: Use compatibility list when checking for timezone

### DIFF
--- a/lib/Controller/TimezoneController.php
+++ b/lib/Controller/TimezoneController.php
@@ -36,7 +36,7 @@ class TimezoneController extends Controller {
 	#[NoAdminRequired]
 	#[UseSession]
 	public function setTimezone(string $timezone, int $timezoneOffset): JSONResponse {
-		if (!in_array($timezone, \DateTimeZone::listIdentifiers())) {
+		if (!in_array($timezone, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC))) {
 			throw new \InvalidArgumentException('Invalid timezone');
 		}
 		if ($this->userId === null) {


### PR DESCRIPTION
Intl.DateTimeFormat().resolvedOptions().timeZone might return some legacy timezone like Europe/Kiev instead of Europe/Kyiv

Fix #1227 

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
